### PR TITLE
Add Permission Lifetime feature study (nightly channel).

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -106,6 +106,34 @@
                 "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"],
                 "country": ["US"]
             }
+        },
+        {
+            "name": "PermissionLifetimeStudy",
+            "experiments": [
+                {
+                    "name": "Enabled",
+                    "probability_weight": 100,
+                    "feature_association": {
+                        "enable_feature": ["PermissionLifetime"]
+                    }
+                },
+                {
+                    "name": "Disabled",
+                    "probability_weight": 0,
+                    "feature_association": {
+                        "disable_feature": ["PermissionLifetime"]
+                    }
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "min_version": "90.0.4430.85",
+                "channel": ["NIGHTLY"],
+                "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
+            }
         }
     ]
 }


### PR DESCRIPTION
Enable `PermissionLifetime` feature on `nightly` on 100% starting with `Brave: 1.25.42 / Chromium: 90.0.4430.85` as per Slack discussion.

[package.json @ 1.25.42](https://github.com/brave/brave-browser/blob/c0d3d25875905f10547ea1db01396ccf105adf6e/package.json)
