### PR TITLE
Enable PermissionLifetime on beta channel (100%).

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -130,8 +130,8 @@
                 }
             ],
             "filter": {
-                "min_version": "90.1.25.42",
-                "channel": ["NIGHTLY"],
+                "min_version": "90.1.25.57",
+                "channel": ["NIGHTLY", "BETA"],
                 "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
             }
         }


### PR DESCRIPTION
Version incremented to include UI changes https://github.com/brave/brave-browser/issues/15603.
Beta rollout to 100% right away as nightly.

https://github.com/brave/brave-variations/pull/34 tested using `brave --variations-server-url=https://variations.bravesoftware.com/seed` on beta build `1.25.60`, works correctly.