### PR TITLE
Add Brave Ads frequency capping study

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -426,6 +426,36 @@
             }
         },
         {
+            "name": "BraveAds.FrequencyCappingStudy",
+            "experiments": [
+                {
+                    "name": "ExcludeAdIfWithinTimeWindow=0h",
+                    "probability_weight": 100,
+                    "parameters": [
+                        {
+                            "name": "exclude_ad_if_dismissed_within_time_window",
+                            "value": "0h"
+                        },
+                        {
+                            "name": "exclude_ad_if_transferred_within_time_window",
+                            "value": "0h"
+                        }
+                    ],
+                    "feature_association": {
+                        "enable_feature": ["FrequencyCapping"]
+                    }
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "channel": ["NIGHTLY"],
+                "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
+            }
+        },
+        {
             "name": "BraveAds.UserActivityStudy",
             "experiments": [
                 {


### PR DESCRIPTION
Change the time window to effectively disable Brave Ads dismissed and transferred frequency caps for nightly channel