### PR TITLE
Fix Brave Ads idle time threshold

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -472,7 +472,7 @@
                         },
                         {
                             "name": "idle_time_threshold",
-                            "value": "5"
+                            "value": "5s"
                         }
                     ],
                     "feature_association": {


### PR DESCRIPTION
Fixes Brave Ads idle time threshold as the value represents a base::TimeDelta object. Default value is 15 seconds, changing to 5 seconds to increase ad delivery