### PR TITLE
Sync reset progress marker release study - disable for investigations

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -516,6 +516,33 @@
                 "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"],
                 "country": ["US", "AU", "CA", "FR", "DE", "IE", "JP", "NZ", "GB"]
             }
+        },
+        {
+            "name": "SyncResetProgressTokenStudy",
+            "experiments": [
+                  {
+                      "name": "Enabled",
+                      "probability_weight": 0,
+                      "feature_association": {
+                          "enable_feature": ["ResetProgressMarkerOnCommitFailures"]
+                      }
+                  },
+                  {
+                      "name": "Disabled",
+                      "probability_weight": 100,
+                      "feature_association": {
+                          "disable_feature": ["ResetProgressMarkerOnCommitFailures"]
+                      }
+                  },
+                  {
+                      "name": "Default",
+                      "probability_weight": 0
+                  }
+            ],
+            "filter": {
+                "channel": ["NIGHTLY", "BETA", "RELEASE"],
+                "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
+            }
         }
     ]
 }


### PR DESCRIPTION
Apply these values for `ResetProgressMarkerOnCommitFailures` feature 
0% enabled, 100% disabled

for investigating sync server issues

CC @jsecretan , @hspencer77 , @yrliou 