### PR TITLE
Update Brave Ads frequency capping study

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -451,8 +451,10 @@
                 }
             ],
             "filter": {
-                "channel": ["NIGHTLY"],
-                "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
+                "min_version": "91.1.26.60",
+                "channel": ["NIGHTLY", "BETA", "RELEASE"],
+                "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"],
+                "country": ["US", "AU", "CA", "FR", "DE", "IE", "JP", "NZ", "GB"]
             }
         },
         {


### PR DESCRIPTION
Roll-out `exclude_ad_if_dismissed_within_time_window` and `exclude_ad_if_transferred_within_time_window` to 1.26.60 and above for tier 1 and 2 regions.