### PR TITLE
Enable native cosmetic filtering backend on production

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2,6 +2,34 @@
     "version": "1",
     "studies": [
         {
+            "name": "NativeCosmeticFilteringStudy",
+            "experiments": [
+                {
+                    "name": "Enabled",
+                    "probability_weight": 100,
+                    "feature_association": {
+                        "enable_feature": ["BraveAdblockCosmeticFilteringNative"]
+                    }
+                },
+                {
+                    "name": "Disabled",
+                    "probability_weight": 0,
+                    "feature_association": {
+                        "disable_feature": ["BraveAdblockCosmeticFilteringNative"]
+                    }
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "min_version": "91.0.4472.114",
+                "channel": ["NIGHTLY"],
+                "platform": ["WINDOWS", "MAC", "LINUX"]
+            }
+        },
+        {
             "name": "VulkanStudy",
             "experiments": [
                 {


### PR DESCRIPTION
Verified that this appears correctly on https://griffin.brave.com and in brave://version on Linux/Release when using the staging URL.