### PR TITLE
Enable native cosmetic filtering backend on Release channel

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -24,8 +24,8 @@
                 }
             ],
             "filter": {
-                "min_version": "91.0.4472.114",
-                "channel": ["NIGHTLY", "BETA"],
+                "min_version": "91.1.26.74",
+                "channel": ["NIGHTLY", "BETA", "RELEASE"],
                 "platform": ["WINDOWS", "MAC", "LINUX"]
             }
         },


### PR DESCRIPTION
Followup to https://github.com/brave/brave-variations/pull/81, still no reported regressions so far