### PR TITLE
Enable MacCoreLocationBackendStudy on release channel

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -656,7 +656,7 @@
             ],
             "filter": {
                 "min_version": "91.1.26.74",
-                "channel": ["BETA", "NIGHTLY"],
+                "channel": ["RELEASE", "BETA", "NIGHTLY"],
                 "platform": ["MAC"]
             }
         }


### PR DESCRIPTION
This feature works well with curren stable channel via staging seed.
issue: https://github.com/brave/brave-browser/issues/10724