### PR TITLE
update regex for ConversionsParametersStudy

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -811,7 +811,7 @@
                     "parameters": [
                         {
                             "name": "conversions_default_conversion_id_pattern",
-                            "value": "<meta.*name=\"ad-conversion-id\".*content=\"([^\"]*)\".*>"
+                            "value": "<meta.*name=\"ad-conversion-id\".*content=\"([-a-zA-Z0-9]*)\".*>"
                         }
                     ],
                     "feature_association": {


### PR DESCRIPTION
# Description
Update regex on Griffin to support spec`[A-Za-z0-9\-]` in the meta-tag for verifiable ad conversions.
This is a temporary solution until https://github.com/brave/brave-browser/issues/17039

# Testing Instructions 

Download and unzip file:
[meta.html.zip](https://github.com/brave/brave-variations/files/7078382/meta.html.zip)

1. Use Charles to map meta.html to `https://brave.com?vac=variation`
2. Confirm that you see "meta tag test page" on the page for successful mapping

3. Load fresh profile with **staging** catalog
4. Enable Ads (geo-US)
5. Force creativeInstanceID `de8274a9-716b-4340-afa1-9bfa52289077` 
    - Option a. Open up local db, `creative_ads` table, and remove all other creatives
    -  Option b. make local catalog and map local via Charles
6. Trigger Push Notification Ad
7. Go to conversion page `https://brave.com?vac=variation`
8. Open local db, `conversions_queue` table, confirm that extracted `conversion_id`. 
    - expected value is `Griffin-9876-meta`
9. Force conversion confirmation to send.
10. Confirm payload contains `conversionEnvelope`

 
 
