### PR TITLE
Add study for BraveAdblockDefault1pBlocking

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2,6 +2,34 @@
     "version": "1",
     "studies": [
         {
+            "name": "Default1pBlockingStudy",
+            "experiments": [
+                {
+                    "name": "Enabled",
+                    "probability_weight": 0,
+                    "feature_association": {
+                        "enable_feature": ["BraveAdblockDefault1pBlocking"]
+                    }
+                },
+                {
+                    "name": "Disabled",
+                    "probability_weight": 100,
+                    "feature_association": {
+                        "disable_feature": ["BraveAdblockDefault1pBlocking"]
+                    }
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "min_version": "92.1.30.57",
+                "channel": ["NIGHTLY", "BETA"],
+                "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
+            }
+        },
+        {
             "name": "NativeCosmeticFilteringStudy",
             "experiments": [
                 {


### PR DESCRIPTION
This should disable the `#brave-adblock-default-1p-blocking` flag for 100% of users on Beta and Nightly. The plan is to begin a more conservative rollout on the Release channel once it hits 1.30.x.