### PR TITLE
Update Brave Talk study to be in Release

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -913,7 +913,7 @@
                 }
             ],
             "filter": {
-                "channel": ["BETA", "NIGHTLY"],
+                "channel": ["RELEASE", "BETA", "NIGHTLY"],
                 "platform": ["WINDOWS", "MAC", "LINUX"]
             }
         }


### PR DESCRIPTION
Per today's triage (Sep 7th), here's the uplift for Talk to RELEASE channel

cc: @jsecretan for the go-ahead. Was uplifted / tested against staging here:
https://github.com/brave/brave-variations/pull/93