### PR TITLE
Rollout custom ad notifcations

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -548,6 +548,10 @@
                     "probability_weight": 30,
                     "parameters": [
                         {
+                            "name": "can_fallback_to_custom_notifications",
+                            "value": "true"
+                        },
+                        {
                             "name": "ad_notification_normalized_display_coordinate_x",
                             "value": "1.0"
                         },
@@ -571,6 +575,12 @@
                 {
                     "name": "CustomAdNotificationDefaultPosition",
                     "probability_weight": 30,
+                    "parameters": [
+                        {
+                            "name": "can_fallback_to_custom_notifications",
+                            "value": "true"
+                        }
+                    ],
                     "feature_association": {
                         "enable_feature": ["CustomAdNotifications"]
                     }
@@ -589,7 +599,37 @@
             ],
             "filter": {
                 "min_version": "92.1.30.19",
-                "channel": ["NIGHTLY", "BETA"],
+                "min_os_version": "10.0.17134.*",
+                "channel": ["BETA", "NIGHTLY"],
+                "platform": ["WINDOWS"]
+            }
+        },
+        {
+            "name": "BraveAds.ShowCustomAdNotificationOnWindowsStudy",
+            "experiments": [
+                {
+                    "name": "Enabled",
+                    "probability_weight": 100,
+                    "feature_association": {
+                        "enable_feature": ["CustomAdNotifications"]
+                    }
+                },
+                {
+                    "name": "Disabled",
+                    "probability_weight": 0,
+                    "feature_association": {
+                        "disable_feature": ["CustomAdNotifications"]
+                    }
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "min_version": "92.1.30.19",
+                "max_os_version": "10.0.16299.*",
+                "channel": ["RELEASE", "NIGHTLY", "BETA"],
                 "platform": ["WINDOWS"]
             }
         },
@@ -642,16 +682,17 @@
             ],
             "filter": {
                 "min_version": "92.1.30.19",
+                "min_os_version": "10.14.*",
                 "channel": ["NIGHTLY", "BETA"],
                 "platform": ["MAC"]
             }
         },
         {
-            "name": "BraveAds.ShowCustomAdNotificationOnLinuxStudy",
+            "name": "BraveAds.ShowCustomAdNotificationOnMacStudy",
             "experiments": [
                 {
                     "name": "Enabled",
-                    "probability_weight": 60,
+                    "probability_weight": 100,
                     "feature_association": {
                         "enable_feature": ["CustomAdNotifications"]
                     }
@@ -665,12 +706,41 @@
                 },
                 {
                     "name": "Default",
-                    "probability_weight": 40
+                    "probability_weight": 0
                 }
             ],
             "filter": {
                 "min_version": "92.1.30.19",
-                "channel": ["NIGHTLY", "BETA"],
+                "max_os_version": "10.13.*",
+                "channel": ["RELEASE", "NIGHTLY", "BETA"],
+                "platform": ["MAC"]
+            }
+        },
+        {
+            "name": "BraveAds.ShowCustomAdNotificationOnLinuxStudy",
+            "experiments": [
+                {
+                    "name": "Enabled",
+                    "probability_weight": 100,
+                    "feature_association": {
+                        "enable_feature": ["CustomAdNotifications"]
+                    }
+                },
+                {
+                    "name": "Disabled",
+                    "probability_weight": 0,
+                    "feature_association": {
+                        "disable_feature": ["CustomAdNotifications"]
+                    }
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "min_version": "92.1.30.19",
+                "channel": ["RELEASE", "NIGHTLY", "BETA"],
                 "platform": ["LINUX"]
             }
         },
@@ -698,7 +768,37 @@
             ],
             "filter": {
                 "min_version": "92.1.30.19",
-                "channel": ["NIGHTLY"],
+                "min_os_version": "8.*",
+                "channel": ["BETA", "NIGHTLY"],
+                "platform": ["ANDROID"]
+            }
+        },
+        {
+            "name": "BraveAds.ShowCustomAdNotificationOnAndroidStudy",
+            "experiments": [
+                {
+                    "name": "Enabled",
+                    "probability_weight": 100,
+                    "feature_association": {
+                        "enable_feature": ["CustomAdNotifications"]
+                    }
+                },
+                {
+                    "name": "Disabled",
+                    "probability_weight": 0,
+                    "feature_association": {
+                        "disable_feature": ["CustomAdNotifications"]
+                    }
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "min_version": "92.1.30.19",
+                "max_os_version": "7.*",
+                "channel": ["RELEASE", "BETA", "NIGHTLY"],
                 "platform": ["ANDROID"]
             }
         },


### PR DESCRIPTION
Windows 10 build 16299 and older or if native notifications are disabled
macOS 10.13 and older
Android 7 and older
All versions of Linux