### PR TITLE
Enable NetworkIsolationKey-based partitions

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -942,6 +942,34 @@
                 "channel": ["RELEASE", "BETA", "NIGHTLY"],
                 "platform": ["WINDOWS", "MAC", "LINUX"]
             }
+        },
+        {
+            "name": "PartitionConnectionsByNetworkIsolationKeyStudy",
+            "experiments": [
+                {
+                    "name": "Enabled",
+                    "probability_weight": 100,
+                    "feature_association": {
+                        "enable_feature": [
+                            "PartitionConnectionsByNetworkIsolationKey",
+                            "PartitionDomainReliabilityByNetworkIsolationKey",
+                            "PartitionExpectCTStateByNetworkIsolationKey",
+                            "PartitionHttpServerPropertiesByNetworkIsolationKey",
+                            "PartitionSSLSessionsByNetworkIsolationKey",
+                            "SplitHostCacheByNetworkIsolationKey"
+                        ]
+                    }
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "min_version": "94.1.31.51",
+                "channel": ["NIGHTLY"],
+                "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
+            }
         }
     ]
 }

--- a/seed/seed.json
+++ b/seed/seed.json
@@ -952,7 +952,6 @@
                     "feature_association": {
                         "enable_feature": [
                             "PartitionConnectionsByNetworkIsolationKey",
-                            "PartitionDomainReliabilityByNetworkIsolationKey",
                             "PartitionExpectCTStateByNetworkIsolationKey",
                             "PartitionHttpServerPropertiesByNetworkIsolationKey",
                             "PartitionSSLSessionsByNetworkIsolationKey",

--- a/seed/seed.json
+++ b/seed/seed.json
@@ -948,7 +948,7 @@
             "experiments": [
                 {
                     "name": "Enabled",
-                    "probability_weight": 100,
+                    "probability_weight": 50,
                     "feature_association": {
                         "enable_feature": [
                             "PartitionConnectionsByNetworkIsolationKey",
@@ -961,7 +961,7 @@
                 },
                 {
                     "name": "Default",
-                    "probability_weight": 0
+                    "probability_weight": 50
                 }
             ],
             "filter": {


### PR DESCRIPTION
https://github.com/brave/brave-browser/issues/11816

Enable the same features Chromium currently is rolling out. At first test it on nightly.