### PR TITLE
Enable chromium partition features on beta.

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1196,6 +1196,33 @@
                 "channel": ["NIGHTLY"],
                 "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
             }
+        },
+        {
+          "name": "PartitionConnectionsByNetworkIsolationKeyStudy",
+          "experiments": [
+              {
+                  "name": "Enabled",
+                  "probability_weight": 25,
+                  "feature_association": {
+                      "enable_feature": [
+                          "PartitionConnectionsByNetworkIsolationKey",
+                          "PartitionExpectCTStateByNetworkIsolationKey",
+                          "PartitionHttpServerPropertiesByNetworkIsolationKey",
+                          "PartitionSSLSessionsByNetworkIsolationKey",
+                          "SplitHostCacheByNetworkIsolationKey"
+                      ]
+                  }
+              },
+              {
+                  "name": "Default",
+                  "probability_weight": 75
+              }
+          ],
+          "filter": {
+              "min_version": "94.1.31.51",
+              "channel": ["BETA"],
+              "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
+          }
         }
     ]
 }


### PR DESCRIPTION
brave/brave-browser#11816

Enable the same features Chromium currently is rolling out. At first test it on nightly.