### PR TITLE
Enable chromium partition features on beta.

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1131,6 +1131,33 @@
             }
         },
         {
+            "name": "PartitionConnectionsByNetworkIsolationKeyStudy",
+            "experiments": [
+                {
+                    "name": "Enabled",
+                    "probability_weight": 25,
+                    "feature_association": {
+                        "enable_feature": [
+                            "PartitionConnectionsByNetworkIsolationKey",
+                            "PartitionExpectCTStateByNetworkIsolationKey",
+                            "PartitionHttpServerPropertiesByNetworkIsolationKey",
+                            "PartitionSSLSessionsByNetworkIsolationKey",
+                            "SplitHostCacheByNetworkIsolationKey"
+                        ]
+                    }
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 75
+                }
+            ],
+            "filter": {
+                "min_version": "94.1.31.51",
+                "channel": ["BETA"],
+                "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
+            }
+        },
+        {
             "name": "OperationalPatternsCollectionStudy",
             "experiments": [
                 {


### PR DESCRIPTION
brave/brave-browser#11816

Enable the same features Chromium currently is rolling out. At first test it on nightly.

tested via seed url replacement. The study appears in beta build properly.