### PR TITLE
Change default 1p blocking policy on Release channel

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -25,7 +25,7 @@
             ],
             "filter": {
                 "min_version": "92.1.30.57",
-                "channel": ["NIGHTLY", "BETA"],
+                "channel": ["NIGHTLY", "BETA", "RELEASE"],
                 "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
             }
         },


### PR DESCRIPTION
This has been in Nightly and Beta for a good amount of time already; no significant reports found.