### PR TITLE
Ad notification timeout study

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -437,6 +437,58 @@
             }
         },
         {
+            "name": "BraveAds.AdNotificationsStudy",
+            "experiments": [
+                {
+                    "name": "AdNotificationTimeout=60",
+                    "probability_weight": 25,
+                    "parameters": [
+                        {
+                            "name": "ad_notification_timeout",
+                            "value": "60"
+                        }
+                    ],
+                    "feature_association": {
+                        "enable_feature": ["AdNotifications"]
+                    }
+                },
+                {
+                    "name": "AdNotificationTimeout=30",
+                    "probability_weight": 25,
+                    "parameters": [
+                        {
+                            "name": "ad_notification_timeout",
+                            "value": "30"
+                        }
+                    ],
+                    "feature_association": {
+                        "enable_feature": ["AdNotifications"]
+                    }
+                },
+                {
+                    "name": "AdNotificationTimeout=15",
+                    "probability_weight": 25,
+                    "parameters": [
+                        {
+                            "name": "ad_notification_timeout",
+                            "value": "15"
+                        }
+                    ],
+                    "feature_association": {
+                        "enable_feature": ["AdNotifications"]
+                    }
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 25
+                }
+            ],
+            "filter": {
+                "channel": ["NIGHTLY"],
+                "platform": ["WINDOWS", "MAC", "LINUX"]
+            }
+        },
+        {
             "name": "AdRewardsStudy",
             "experiments": [
                 {


### PR DESCRIPTION
Field trial to lower the push notification ad timeout on desktop

-  Default (120 seconds, 25% of users)
-  60 seconds (25% of users)
-  30 seconds (25% of users)
-  15 seconds (25% of users)
