### PR TITLE
Enable pratitioned blink memory cache on nightly.

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1065,6 +1065,29 @@
             }
         },
         {
+            "name": "PartitionBlinkMemoryCacheStudy",
+            "experiments": [
+                {
+                    "name": "Enabled",
+                    "probability_weight": 100,
+                    "feature_association": {
+                        "enable_feature": [
+                            "PartitionBlinkMemoryCache"
+                        ]
+                    }
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "min_version": "96.1.34.20",
+                "channel": ["NIGHTLY"],
+                "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
+            }
+        },
+        {
             "name": "RequestAdsEnabledApiStudy",
             "experiments": [
                 {

--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1069,7 +1069,7 @@
             "experiments": [
                 {
                     "name": "Enabled",
-                    "probability_weight": 100,
+                    "probability_weight": 50,
                     "feature_association": {
                         "enable_feature": [
                             "PartitionBlinkMemoryCache"
@@ -1078,7 +1078,7 @@
                 },
                 {
                     "name": "Default",
-                    "probability_weight": 0
+                    "probability_weight": 50
                 }
             ],
             "filter": {


### PR DESCRIPTION
Nightly 50%, tested manually.

### What the study does?
* enables renderer logic for in-memory cache partitioning inside third-party frames.

### What can go wrong? Is data loss possible?
* the most bad thing that can happen is 3p frame crash.
* data loss is very unlikely (no browser-process change).

https://github.com/brave/brave-browser/issues/18831