### PR TITLE
CLEANUP - remove unused BraveTalk study (production)

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -945,33 +945,6 @@
             }
         },
         {
-            "name": "BraveTalkStudy",
-            "experiments": [
-                {
-                    "name": "Enabled",
-                    "probability_weight": 100,
-                    "feature_association": {
-                        "enable_feature": ["BraveTalk"]
-                    }
-                },
-                {
-                    "name": "Disabled",
-                    "probability_weight": 0,
-                    "feature_association": {
-                        "disable_feature": ["BraveTalk"]
-                    }
-                },
-                {
-                    "name": "Default",
-                    "probability_weight": 0
-                }
-            ],
-            "filter": {
-                "channel": ["RELEASE", "BETA", "NIGHTLY"],
-                "platform": ["WINDOWS", "MAC", "LINUX"]
-            }
-        },
-        {
             "name": "PartitionConnectionsByNetworkIsolationKeyStudy",
             "experiments": [
                 {


### PR DESCRIPTION
Fixes https://github.com/brave/brave-variations/issues/133

Should be safe to merge as https://github.com/brave/brave-core/pull/10311 was in 1.32.x, which is now release channel