### PR TITLE
Enables brave news at 100% for nightly android

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -777,7 +777,7 @@
             "experiments": [
                 {
                     "name": "Enabled",
-                    "probability_weight": 25,
+                    "probability_weight": 100,
                     "feature_association": {
                         "enable_feature": ["BraveNews"]
                     }
@@ -791,7 +791,7 @@
                 },
                 {
                     "name": "Default",
-                    "probability_weight": 75
+                    "probability_weight": 0
                 }
             ],
             "filter": {


### PR DESCRIPTION
Issue here: https://github.com/brave/brave-browser/issues/19770
Percentages discussion here: https://bravesoftware.slack.com/archives/CU56GUJ1H/p1638207099192300