### PR TITLE
Test several feature weights for V2 Ad Serving

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -409,7 +409,7 @@
             "experiments": [
                 {
                     "name": "MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=8/MaximumInlineContentAdsPerDay=40/AdServingVersion=1",
-                    "probability_weight": 50,
+                    "probability_weight": 20,
                     "parameters": [
                         {
                             "name": "maximum_ad_notifications_per_day",
@@ -434,7 +434,7 @@
                 },
                 {
                     "name": "MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=8/MaximumInlineContentAdsPerDay=40/AdServingVersion=2",
-                    "probability_weight": 50,
+                    "probability_weight": 20,
                     "parameters": [
                         {
                             "name": "maximum_ad_notifications_per_day",
@@ -451,6 +451,93 @@
                         {
                             "name": "ad_serving_version",
                             "value": "2"
+                        }
+                    ],
+                    "feature_association": {
+                        "enable_feature": ["AdServing"]
+                    }
+                },
+                {
+                    "name": "MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=8/MaximumInlineContentAdsPerDay=40/AdServingVersion=2/AdPredictorWeights=16.0,8.0,16.0,8.0,0.0,0.0,0.0",
+                    "probability_weight": 20,
+                    "parameters": [
+                        {
+                            "name": "maximum_ad_notifications_per_day",
+                            "value": "100"
+                        },
+                        {
+                            "name": "maximum_inline_content_ads_per_hour",
+                            "value": "8"
+                        },
+                        {
+                            "name": "maximum_inline_content_ads_per_day",
+                            "value": "40"
+                        },
+                        {
+                            "name": "ad_serving_version",
+                            "value": "2"
+                        },
+                        {
+                            "name": "ad_predictor_weights",
+                            "value": "16.0, 8.0, 16.0, 8.0, 0.0, 0.0, 0.0"
+                        }
+                    ],
+                    "feature_association": {
+                        "enable_feature": ["AdServing"]
+                    }
+                },
+                {
+                    "name": "MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=8/MaximumInlineContentAdsPerDay=40/AdServingVersion=2/AdPredictorWeights=0.0,0.0,0.0,0.0,16.0,16.0,0.0",
+                    "probability_weight": 20,
+                    "parameters": [
+                        {
+                            "name": "maximum_ad_notifications_per_day",
+                            "value": "100"
+                        },
+                        {
+                            "name": "maximum_inline_content_ads_per_hour",
+                            "value": "8"
+                        },
+                        {
+                            "name": "maximum_inline_content_ads_per_day",
+                            "value": "40"
+                        },
+                        {
+                            "name": "ad_serving_version",
+                            "value": "2"
+                        },
+                        {
+                            "name": "ad_predictor_weights",
+                            "value": "0.0, 0.0, 0.0, 0.0, 16.0, 16.0, 0.0"
+                        }
+                    ],
+                    "feature_association": {
+                        "enable_feature": ["AdServing"]
+                    }
+                },
+                {
+                    "name": "MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=8/MaximumInlineContentAdsPerDay=40/AdServingVersion=2/AdPredictorWeights=32.0,16.0,16.0,8.0,4.0,2.0,1.0",
+                    "probability_weight": 20,
+                    "parameters": [
+                        {
+                            "name": "maximum_ad_notifications_per_day",
+                            "value": "100"
+                        },
+                        {
+                            "name": "maximum_inline_content_ads_per_hour",
+                            "value": "8"
+                        },
+                        {
+                            "name": "maximum_inline_content_ads_per_day",
+                            "value": "40"
+                        },
+                        {
+                            "name": "ad_serving_version",
+                            "value": "2"
+                        },
+                        {
+                            "name": "ad_predictor_weights",
+                            "value": "32.0, 16.0, 16.0, 8.0, 4.0, 2.0, 1.0"
                         }
                     ],
                     "feature_association": {


### PR DESCRIPTION
Resolves https://github.com/brave/brave-variations/issues/181

Following #123 we want to test different combinations of feature parameters for V2 ad serving. The griffin parameter under test is a string of 7 floats, decomposing into the following feature weights:

1. DoesMatchIntentChildSegments
2. DoesMatchIntentParentSegments
3. DoesMatchInterestChildSegments
4. DoesMatchInterestParentSegments
5. AdLastSeenHoursAgo
6. AdvertiserLastSeenHoursAgo
7. Priority

Thus we aim to split the study into 5 groups as follows:

1. (20%) Ad Serving V1
2. (20%) Ad Serving V2 with default weights (all weights are set to 1.0)
3. (20%) Ad Serving V2 with "16.0, 8.0, 16.0, 8.0, 0.0, 0.0, 0.0" (isolate segment feature effects)
4. (20%) Ad Serving V2 with "0.0, 0.0, 0.0, 0.0, 16.0, 16.0, 0.0" (isolate recency feature effects)
5. (20%) Ad Serving V2 with "32.0, 16.0, 16.0, 8.0, 4.0, 2.0, 1.0" (somewhat arbitrary weights w/ bias towards segment features)
6. In addition to Nightly, the study should run in Beta channel.