### PR TITLE
Enable BraveAdblockCookieListDefault on Nightly/Beta (production)

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -58,6 +58,34 @@
             }
         },
         {
+            "name": "CookieListDefaultStudy",
+            "experiments": [
+                {
+                    "name": "Enabled",
+                    "probability_weight": 100,
+                    "feature_association": {
+                        "enable_feature": ["BraveAdblockCookieListDefault"]
+                    }
+                },
+                {
+                    "name": "Disabled",
+                    "probability_weight": 0,
+                    "feature_association": {
+                        "disable_feature": ["BraveAdblockCookieListDefault"]
+                    }
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "min_version": "97.1.35.39",
+                "channel": ["NIGHTLY", "BETA"],
+                "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
+            }
+        },
+        {
             "name": "NativeCosmeticFilteringStudy",
             "experiments": [
                 {


### PR DESCRIPTION
Rebase of https://github.com/brave/brave-variations/pull/188 to the `production` branch, to be merged after verifying the staging PR.

> This feature enables `Easylist-Cookie List - Filter Obtrusive Cookie Notices` from brave://adblock by default, although it can still be overridden by a user who wishes to disable the list.