### PR TITLE
HangWatcher to nightly 50%

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -886,6 +886,41 @@
                 "channel": ["NIGHTLY"],
                 "platform": ["ANDROID"]
             }
+        },
+        {
+            "name": "HangWatcher",
+            "experiments": [
+                {
+                    "name": "AdNotificationTimeout=60",
+                    "probability_weight": 50,
+                    "parameters": [
+                        {
+                            "name": "ui_thread_log_level",
+                            "value": "2"
+                        },
+                        {
+                            "name": "io_thread_log_level",
+                            "value": "2"
+                        },
+                        {
+                            "name": "threadpool_log_level",
+                            "value": "2"
+                        }
+                    ],
+                    "feature_association": {
+                        "enable_feature": ["HangWatcher"]
+                    }
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 50
+                }
+            ],
+            "filter": {
+                "channel": ["NIGHTLY"],
+                "platform": ["WINDOWS", "MAC", "LINUX"],
+                "min_version": "97.1.36.14"
+            }
         }
     ]
 }

--- a/seed/seed.json
+++ b/seed/seed.json
@@ -891,7 +891,7 @@
             "name": "HangWatcher",
             "experiments": [
                 {
-                    "name": "AdNotificationTimeout=60",
+                    "name": "HangWatcherEnableDumps",
                     "probability_weight": 50,
                     "parameters": [
                         {


### PR DESCRIPTION
Nightly 50%, tested manually.
Security review: brave/security#659

### What the study does?
* enables sending crash dumps if a hang happens. The logic of hang detections are chromium and already works everywhere, but record only UMA.

### What can go wrong? Is data loss possible?
* A lot of dumps because a lot of hangs or false positives.

`min_version` is set to current nightly with landed https://github.com/brave/brave-browser/issues/19822
(the changed description in the settings page).

PRs to master:
https://github.com/brave/brave-variations/pull/192
https://github.com/brave/brave-variations/pull/193

The root issue:
https://github.com/brave/brave-browser/issues/20304
