### PR TITLE
Force disable features to fix renderer/browser inconsistency.

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -883,6 +883,35 @@
             }
         },
         {
+            "name": "ForceDisableBlinkFeatures",
+            "experiments": [
+                {
+                    "name": "Enabled",
+                    "probability_weight": 100,
+                    "feature_association": {
+                        "disable_feature": [
+                            "IdleDetection",
+                            "WebNFC",
+                            "WebOTP",
+                            "ComputePressure",
+                            "SignedExchangeSubresourcePrefetch",
+                            "TextFragmentAnchor",
+                            "NavigatorPluginsFixed"
+                        ]
+                    }
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "min_version": "96.1.34.4",
+                "channel": ["NIGHTLY", "BETA", "RELEASE"],
+                "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
+            }
+        },
+        {
             "name": "RequestAdsEnabledApiStudy",
             "experiments": [
                 {


### PR DESCRIPTION
https://github.com/brave/brave-browser/issues/20436

These features are mirrored in blink using some vague logic which checks for overrides and only then applies feature states. See https://github.com/chromium/chromium/blob/8df70adc0091a6818772c55d68e1670a691f3a7d/content/child/runtime_features.cc#L137-L153

This study will force these features to be "overridden" which will apply the state properly. Meanwhile I'll add a change to core to handle this case properly without this Griffin study in future.