### PR TITLE
Remove v2 Brave Ads serving pipeline from the beta channel

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -412,7 +412,7 @@
                 }
             ],
             "filter": {
-                "channel": ["RELEASE"],
+                "channel": ["RELEASE", "BETA"],
                 "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"],
                 "country": ["US", "AU", "CA", "FR", "DE", "IE", "JP", "NZ", "GB"]
             }
@@ -559,7 +559,7 @@
                 }
             ],
             "filter": {
-                "channel": ["NIGHTLY", "BETA"],
+                "channel": ["NIGHTLY"],
                 "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"],
                 "country": ["US", "AU", "CA", "FR", "DE", "IE", "JP", "NZ", "GB"]
             }


### PR DESCRIPTION
Remove v2 Brave Ads serving pipeline from the beta channel until this feature has been fully tested on nightly cc @kjozwiak @stephendonner