### PR TITLE
Disable NavigationThreadingOptimizations on Desktop

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1011,6 +1011,22 @@
                 "channel": ["NIGHTLY", "BETA", "RELEASE"],
                 "platform": ["ANDROID"]
             }
+        },
+        {
+            "name": "NavigationThreadingOptimizationsCompat",
+            "experiments": [
+                {
+                    "name": "Disabled",
+                    "probability_weight": 100,
+                    "feature_association": {
+                        "disable_feature": ["NavigationThreadingOptimizations"]
+                    }
+                }
+             ],
+            "filter": {
+                "platform": ["WINDOWS", "MAC", "LINUX"],
+                "max_version": "99.0.0.0"
+            }
         }
     ]
 }


### PR DESCRIPTION
This is currently disabled on Chrome, at least for version 98 and for desktop. I am unsure if this problem affects Android or when we update to Chromium 99, so I've left it as default for android and desktop with cr99+ (enabled in brave-core/chromium).

Fix: https://github.com/brave/brave-browser/issues/21029