### PR TITLE
Disable NavigationThreadingOptimizations on Desktop for 5% of users - Production

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1039,6 +1039,26 @@
                 "channel": ["NIGHTLY", "BETA", "RELEASE"],
                 "platform": ["ANDROID"]
             }
+        },
+        {
+            "name": "NavigationThreadingOptimizationsCompat",
+            "experiments": [
+                {
+                    "name": "Disabled",
+                    "probability_weight": 100,
+                    "feature_association": {
+                        "disable_feature": ["NavigationThreadingOptimizations"]
+                    }
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+             ],
+            "filter": {
+                "platform": ["WINDOWS", "MAC", "LINUX"],
+                "channel": ["NIGHTLY", "BETA", "RELEASE"]
+            }
         }
     ]
 }

--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1045,14 +1045,14 @@
             "experiments": [
                 {
                     "name": "Disabled",
-                    "probability_weight": 100,
+                    "probability_weight": 5,
                     "feature_association": {
                         "disable_feature": ["NavigationThreadingOptimizations"]
                     }
                 },
                 {
                     "name": "Default",
-                    "probability_weight": 0
+                    "probability_weight": 95
                 }
              ],
             "filter": {

--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1045,6 +1045,26 @@
             "experiments": [
                 {
                     "name": "Disabled",
+                    "probability_weight": 100,
+                    "feature_association": {
+                        "disable_feature": ["NavigationThreadingOptimizations"]
+                    }
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+             ],
+            "filter": {
+                "platform": ["WINDOWS", "MAC", "LINUX"],
+                "channel": ["NIGHTLY", "BETA"]
+            }
+        },
+        {
+            "name": "NavigationThreadingOptimizationsCompat",
+            "experiments": [
+                {
+                    "name": "Disabled",
                     "probability_weight": 5,
                     "feature_association": {
                         "disable_feature": ["NavigationThreadingOptimizations"]
@@ -1057,7 +1077,7 @@
              ],
             "filter": {
                 "platform": ["WINDOWS", "MAC", "LINUX"],
-                "channel": ["NIGHTLY", "BETA", "RELEASE"]
+                "channel": ["RELEASE"]
             }
         }
     ]


### PR DESCRIPTION
## Test plan
To reproduce (on a bad profile). Run the following WITH and WITHOUT the study:
1. open [news.ycombinator.com](http://news.ycombinator.com/)
2. open devtools
3. go to network tab
4. check "disable cache"
5. Refresh
6. Observe gap between first request and subsequent requests

Here is a bad profile you can use 😄 
[slow-profile.zip](https://github.com/brave/brave-variations/files/8051775/slow-profile.zip)


## Description
Uplift of staging version merged with https://github.com/brave/brave-variations/pull/216 / https://github.com/brave/brave-variations/pull/218 / https://github.com/brave/brave-variations/pull/219

NOTE: do not merge yet. We need to finish testing and figure out what percentages to roll out

> This is currently disabled on Chrome, at least for version 98 and for desktop. I am unsure if this problem affects Android or when we update to Chromium 99, so I've left it as default for android and desktop with cr99+ (enabled in brave-core/chromium).
> 
> Fix: https://github.com/brave/brave-browser/issues/21029