### PR TITLE
Remove `max_version` for `NavigationThreadingOptimizationsCompat` study (Staging) 

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1029,8 +1029,7 @@
              ],
             "filter": {
                 "platform": ["WINDOWS", "MAC", "LINUX"],
-                "channel": ["NIGHTLY", "BETA", "RELEASE"],
-                "max_version": "99.0.0.0"
+                "channel": ["NIGHTLY", "BETA", "RELEASE"]
             }
         }
     ]


### PR DESCRIPTION
This is being removed in https://github.com/brave/brave-variations/pull/217 (production)- want to match the same criteria in staging