### PR TITLE
Disable NavigationThreadingOptimizations on Desktop for 50% of users - Production

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1065,14 +1065,14 @@
             "experiments": [
                 {
                     "name": "Disabled",
-                    "probability_weight": 5,
+                    "probability_weight": 50,
                     "feature_association": {
                         "disable_feature": ["NavigationThreadingOptimizations"]
                     }
                 },
                 {
                     "name": "Default",
-                    "probability_weight": 95
+                    "probability_weight": 50
                 }
              ],
             "filter": {


### PR DESCRIPTION
## Test plan
To reproduce (on a bad profile). Run the following WITH and WITHOUT the study:
1. open [news.ycombinator.com](http://news.ycombinator.com/)
2. open devtools
3. go to network tab
4. check "disable cache"
5. Refresh
6. Observe gap between first request and subsequent requests

Here is a bad profile you can use 😄 
[slow-profile.zip](https://github.com/brave/brave-variations/files/8051775/slow-profile.zip)


## Description
Follow up to https://github.com/brave/brave-variations/pull/217 which had disabled for 5%