### PR TITLE
Enable 1PES domain block functionality on 20% nightly.

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -303,6 +303,30 @@
             }
         },
         {
+          "name": "FirstPartyEphemeralDomainBlockStudy",
+          "experiments": [
+              {
+                  "name": "Enabled",
+                  "probability_weight": 20,
+                  "feature_association": {
+                      "enable_feature": [
+                          "BraveFirstPartyEphemeralStorage",
+                          "BraveDomainBlock1PES"
+                      ]
+                  }
+              },
+              {
+                  "name": "Default",
+                  "probability_weight": 80
+              }
+          ],
+          "filter": {
+              "min_version": "98.1.37.50",
+              "channel": ["NIGHTLY"],
+              "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
+          }
+        },
+        {
             "name": "SpeedreaderReleaseStudy",
             "experiments": [
                 {


### PR DESCRIPTION
Enable 1PES mode availability in browser and enable automatic temporary 1PES when visiting blocked websites in Standard blocking mode.

This study consist of two features: 
1. `BraveFirstPartyEphemeralStorage` - changes one of possible cookie settings from `Always clear cookies when windows are closed` to `Sites that clear cookies when you close them`. Which allows user to basically always enable ephemeral mode for a website if it's added to the list.
2. `BraveDomainBlock1PES` - enables automatic temporary 1PES for a website if it's in a blocked domains list.

https://github.com/brave/brave-browser/issues/19099
https://github.com/brave/brave-browser/issues/20702