### PR TITLE
Disable NavigationThreadingOptimizations on Desktop for 100% of users - Production

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1037,14 +1037,14 @@
             "experiments": [
                 {
                     "name": "Disabled",
-                    "probability_weight": 50,
+                    "probability_weight": 100,
                     "feature_association": {
                         "disable_feature": ["NavigationThreadingOptimizations"]
                     }
                 },
                 {
                     "name": "Default",
-                    "probability_weight": 50
+                    "probability_weight": 0
                 }
              ],
             "filter": {


### PR DESCRIPTION
## Test plan
To reproduce (on a bad profile). Run the following WITH and WITHOUT the study:
1. open [news.ycombinator.com](http://news.ycombinator.com/)
2. open devtools
3. go to network tab
4. check "disable cache"
5. Refresh
6. Observe gap between first request and subsequent requests

Here is a bad profile you can use 😄 
[slow-profile.zip](https://github.com/brave/brave-variations/files/8051775/slow-profile.zip)


## Description
- Follow up to https://github.com/brave/brave-variations/pull/217 which had disabled for 5%
- Follow up to https://github.com/brave/brave-variations/pull/221 which had disabled for 50%