### PR TITLE
Increase inline content ads per hour/day and roll-out to all regions

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -462,7 +462,7 @@
             "name": "AdServingStudy",
             "experiments": [
                 {
-                    "name": "MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=8/MaximumInlineContentAdsPerDay=40",
+                    "name": "MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=12/MaximumInlineContentAdsPerDay=60",
                     "probability_weight": 100,
                     "parameters": [
                         {
@@ -471,11 +471,11 @@
                         },
                         {
                             "name": "maximum_inline_content_ads_per_hour",
-                            "value": "8"
+                            "value": "12"
                         },
                         {
                             "name": "maximum_inline_content_ads_per_day",
-                            "value": "40"
+                            "value": "60"
                         }
                     ],
                     "feature_association": {
@@ -488,16 +488,15 @@
                 }
             ],
             "filter": {
-                "channel": ["BETA", "RELEASE"],
-                "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"],
-                "country": ["US", "AU", "CA", "FR", "DE", "IE", "JP", "NZ", "GB"]
+                "channel": ["RELEASE", "BETA"],
+                "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
             }
         },
         {
             "name": "BraveAds.AdServingStudy",
             "experiments": [
                 {
-                    "name": "MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=8/MaximumInlineContentAdsPerDay=40/AdServingVersion=1",
+                    "name": "MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=12/MaximumInlineContentAdsPerDay=60/AdServingVersion=1",
                     "probability_weight": 20,
                     "parameters": [
                         {
@@ -506,11 +505,11 @@
                         },
                         {
                             "name": "maximum_inline_content_ads_per_hour",
-                            "value": "8"
+                            "value": "12"
                         },
                         {
                             "name": "maximum_inline_content_ads_per_day",
-                            "value": "40"
+                            "value": "60"
                         },
                         {
                             "name": "ad_serving_version",
@@ -522,7 +521,7 @@
                     }
                 },
                 {
-                    "name": "MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=8/MaximumInlineContentAdsPerDay=40/AdServingVersion=2",
+                    "name": "MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=12/MaximumInlineContentAdsPerDay=60/AdServingVersion=2",
                     "probability_weight": 20,
                     "parameters": [
                         {
@@ -531,11 +530,11 @@
                         },
                         {
                             "name": "maximum_inline_content_ads_per_hour",
-                            "value": "8"
+                            "value": "12"
                         },
                         {
                             "name": "maximum_inline_content_ads_per_day",
-                            "value": "40"
+                            "value": "60"
                         },
                         {
                             "name": "ad_serving_version",
@@ -547,7 +546,7 @@
                     }
                 },
                 {
-                    "name": "MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=8/MaximumInlineContentAdsPerDay=40/AdServingVersion=2/AdPredictorWeights=16.0,8.0,16.0,8.0,0.0,0.0,0.0",
+                    "name": "MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=12/MaximumInlineContentAdsPerDay=60/AdServingVersion=2/AdPredictorWeights=16.0,8.0,16.0,8.0,0.0,0.0,0.0",
                     "probability_weight": 20,
                     "parameters": [
                         {
@@ -556,11 +555,11 @@
                         },
                         {
                             "name": "maximum_inline_content_ads_per_hour",
-                            "value": "8"
+                            "value": "12"
                         },
                         {
                             "name": "maximum_inline_content_ads_per_day",
-                            "value": "40"
+                            "value": "60"
                         },
                         {
                             "name": "ad_serving_version",
@@ -576,7 +575,7 @@
                     }
                 },
                 {
-                    "name": "MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=8/MaximumInlineContentAdsPerDay=40/AdServingVersion=2/AdPredictorWeights=0.0,0.0,0.0,0.0,16.0,16.0,0.0",
+                    "name": "MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=12/MaximumInlineContentAdsPerDay=60/AdServingVersion=2/AdPredictorWeights=0.0,0.0,0.0,0.0,16.0,16.0,0.0",
                     "probability_weight": 20,
                     "parameters": [
                         {
@@ -585,11 +584,11 @@
                         },
                         {
                             "name": "maximum_inline_content_ads_per_hour",
-                            "value": "8"
+                            "value": "12"
                         },
                         {
                             "name": "maximum_inline_content_ads_per_day",
-                            "value": "40"
+                            "value": "60"
                         },
                         {
                             "name": "ad_serving_version",
@@ -605,7 +604,7 @@
                     }
                 },
                 {
-                    "name": "MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=8/MaximumInlineContentAdsPerDay=40/AdServingVersion=2/AdPredictorWeights=32.0,16.0,16.0,8.0,4.0,2.0,1.0",
+                    "name": "MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=12/MaximumInlineContentAdsPerDay=60/AdServingVersion=2/AdPredictorWeights=32.0,16.0,16.0,8.0,4.0,2.0,1.0",
                     "probability_weight": 20,
                     "parameters": [
                         {
@@ -614,11 +613,11 @@
                         },
                         {
                             "name": "maximum_inline_content_ads_per_hour",
-                            "value": "8"
+                            "value": "12"
                         },
                         {
                             "name": "maximum_inline_content_ads_per_day",
-                            "value": "40"
+                            "value": "60"
                         },
                         {
                             "name": "ad_serving_version",


### PR DESCRIPTION
Change inline content ad delivery to:
- 12 ads per hour
- 60 ads per day
- All regions
