### PR TITLE
Do not exclude ads within time window for all regions

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -378,8 +378,7 @@
             "filter": {
                 "min_version": "91.1.26.60",
                 "channel": ["NIGHTLY", "BETA", "RELEASE"],
-                "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"],
-                "country": ["US", "AU", "CA", "FR", "DE", "IE", "JP", "NZ", "GB"]
+                "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
             }
         },
         {


### PR DESCRIPTION
Do not exclude ads if dismissed or landed (aka transferred) within a time window by setting the time window to 0 hours in `FrequencyCapping`/`exclude_ad_if_dismissed_within_time_window` and `FrequencyCapping`/`exclude_ad_if_transferred_within_time_window` within the seed.