### PR TITLE
Change default ad notifications per hour from 5 to 10

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -434,9 +434,13 @@
             "name": "AdServingStudy",
             "experiments": [
                 {
-                    "name": "MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=12/MaximumInlineContentAdsPerDay=60",
+                    "name": "DefaultAdNotificationsPerHour=10/MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=12/MaximumInlineContentAdsPerDay=60",
                     "probability_weight": 100,
                     "parameters": [
+                        {
+                            "name": "default_ad_notifications_per_hour",
+                            "value": "10"
+                        },
                         {
                             "name": "maximum_ad_notifications_per_day",
                             "value": "100"
@@ -468,9 +472,13 @@
             "name": "BraveAds.AdServingStudy",
             "experiments": [
                 {
-                    "name": "MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=12/MaximumInlineContentAdsPerDay=60/AdServingVersion=1",
+                    "name": "DefaultAdNotificationsPerHour=10/MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=12/MaximumInlineContentAdsPerDay=60/AdServingVersion=1",
                     "probability_weight": 20,
                     "parameters": [
+                        {
+                            "name": "default_ad_notifications_per_hour",
+                            "value": "10"
+                        },
                         {
                             "name": "maximum_ad_notifications_per_day",
                             "value": "100"
@@ -493,9 +501,13 @@
                     }
                 },
                 {
-                    "name": "MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=12/MaximumInlineContentAdsPerDay=60/AdServingVersion=2",
+                    "name": "DefaultAdNotificationsPerHour=10/MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=12/MaximumInlineContentAdsPerDay=60/AdServingVersion=2",
                     "probability_weight": 20,
                     "parameters": [
+                        {
+                            "name": "default_ad_notifications_per_hour",
+                            "value": "10"
+                        },
                         {
                             "name": "maximum_ad_notifications_per_day",
                             "value": "100"
@@ -518,9 +530,13 @@
                     }
                 },
                 {
-                    "name": "MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=12/MaximumInlineContentAdsPerDay=60/AdServingVersion=2/AdPredictorWeights=16.0,8.0,16.0,8.0,0.0,0.0,0.0",
+                    "name": "DefaultAdNotificationsPerHour=10/MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=12/MaximumInlineContentAdsPerDay=60/AdServingVersion=2/AdPredictorWeights=16.0,8.0,16.0,8.0,0.0,0.0,0.0",
                     "probability_weight": 20,
                     "parameters": [
+                        {
+                            "name": "default_ad_notifications_per_hour",
+                            "value": "10"
+                        },
                         {
                             "name": "maximum_ad_notifications_per_day",
                             "value": "100"
@@ -547,9 +563,13 @@
                     }
                 },
                 {
-                    "name": "MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=12/MaximumInlineContentAdsPerDay=60/AdServingVersion=2/AdPredictorWeights=0.0,0.0,0.0,0.0,16.0,16.0,0.0",
+                    "name": "DefaultAdNotificationsPerHour=10/MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=12/MaximumInlineContentAdsPerDay=60/AdServingVersion=2/AdPredictorWeights=0.0,0.0,0.0,0.0,16.0,16.0,0.0",
                     "probability_weight": 20,
                     "parameters": [
+                        {
+                            "name": "default_ad_notifications_per_hour",
+                            "value": "10"
+                        },
                         {
                             "name": "maximum_ad_notifications_per_day",
                             "value": "100"
@@ -576,9 +596,13 @@
                     }
                 },
                 {
-                    "name": "MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=12/MaximumInlineContentAdsPerDay=60/AdServingVersion=2/AdPredictorWeights=32.0,16.0,16.0,8.0,4.0,2.0,1.0",
+                    "name": "DefaultAdNotificationsPerHour=10/MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=12/MaximumInlineContentAdsPerDay=60/AdServingVersion=2/AdPredictorWeights=32.0,16.0,16.0,8.0,4.0,2.0,1.0",
                     "probability_weight": 20,
                     "parameters": [
+                        {
+                            "name": "default_ad_notifications_per_hour",
+                            "value": "10"
+                        },
                         {
                             "name": "maximum_ad_notifications_per_day",
                             "value": "100"


### PR DESCRIPTION
Change default ads per hour from 5 to 10 for new users or users who have not previously changed their default value. See `AdServing`/`default_ad_notifications_per_hour`