### PR TITLE
Decrease Brave Ads idle time threshold and remove user activity for all regions

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -387,7 +387,7 @@
             "experiments": [
                 {
                     "name": "Triggers=EMPTY/Threshold=0.0/IdleTimeThreshold=5",
-                    "probability_weight": 90,
+                    "probability_weight": 100,
                     "parameters": [
                         {
                             "name": "triggers",
@@ -407,27 +407,13 @@
                     }
                 },
                 {
-                    "name": "IdleTimeThreshold=5",
-                    "probability_weight": 10,
-                    "parameters": [
-                        {
-                            "name": "idle_time_threshold",
-                            "value": "5s"
-                        }
-                    ],
-                    "feature_association": {
-                        "enable_feature": ["UserActivity"]
-                    }
-                },
-                {
                     "name": "Default",
                     "probability_weight": 0
                 }
             ],
             "filter": {
                 "channel": ["NIGHTLY", "BETA", "RELEASE"],
-                "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"],
-                "country": ["US", "AU", "CA", "FR", "DE", "IE", "JP", "NZ", "GB"]
+                "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
             }
         },
         {


### PR DESCRIPTION
Decrease Brave Ads idle time threshold from 15 seconds to 5 seconds for all regions. This is the time a user has to be idle before we attempt to serve an ad. Set user activity threshold to 0 for all regions.