### PR TITLE
Decrease Brave Ads idle time threshold and remove user activity for all regions

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -415,7 +415,7 @@
             "experiments": [
                 {
                     "name": "Triggers=EMPTY/Threshold=0.0/IdleTimeThreshold=5",
-                    "probability_weight": 90,
+                    "probability_weight": 100,
                     "parameters": [
                         {
                             "name": "triggers",
@@ -435,27 +435,13 @@
                     }
                 },
                 {
-                    "name": "IdleTimeThreshold=5",
-                    "probability_weight": 10,
-                    "parameters": [
-                        {
-                            "name": "idle_time_threshold",
-                            "value": "5s"
-                        }
-                    ],
-                    "feature_association": {
-                        "enable_feature": ["UserActivity"]
-                    }
-                },
-                {
                     "name": "Default",
                     "probability_weight": 0
                 }
             ],
             "filter": {
                 "channel": ["NIGHTLY", "BETA", "RELEASE"],
-                "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"],
-                "country": ["US", "AU", "CA", "FR", "DE", "IE", "JP", "NZ", "GB"]
+                "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
             }
         },
         {


### PR DESCRIPTION
Decrease idle time threshold before serving ads from 15s to 5s for all regions and remove user activity threshold for all regions