### PR TITLE
Enable 1PES support only on builds with fixed cookie cleanup logic.

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -293,7 +293,7 @@
               }
           ],
           "filter": {
-              "min_version": "98.1.37.50",
+              "min_version": "101.1.38.109",
               "channel": ["NIGHTLY", "BETA", "RELEASE"],
               "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
           }


### PR DESCRIPTION
Enable this functionality: https://github.com/brave/brave-browser/issues/19099
On builds which include this fix: https://github.com/brave/brave-browser/issues/22493