### PR TITLE
Speedreader 100% in all channels.

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -359,14 +359,14 @@
             "experiments": [
                 {
                     "name": "Enabled",
-                    "probability_weight": 40,
+                    "probability_weight": 100,
                     "feature_association": {
                         "enable_feature": ["Speedreader"]
                     }
                 },
                 {
                     "name": "Disabled",
-                    "probability_weight": 60,
+                    "probability_weight": 0,
                     "feature_association": {
                         "disable_feature": ["Speedreader"]
                     }


### PR DESCRIPTION
There is no sense in keeping speedreader enabled for 40% in release channel. As the feature is more or less stable now, I think we should push to 100%