### PR TITLE
Re-enable cookie dialog blocking list on Nightly

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -90,14 +90,14 @@
             "experiments": [
                 {
                     "name": "Enabled",
-                    "probability_weight": 0,
+                    "probability_weight": 100,
                     "feature_association": {
                         "enable_feature": ["BraveAdblockCookieListDefault"]
                     }
                 },
                 {
                     "name": "Disabled",
-                    "probability_weight": 100,
+                    "probability_weight": 0,
                     "feature_association": {
                         "disable_feature": ["BraveAdblockCookieListDefault"]
                     }
@@ -109,7 +109,7 @@
             ],
             "filter": {
                 "min_version": "97.1.35.39",
-                "channel": ["NIGHTLY", "BETA"],
+                "channel": ["NIGHTLY"],
                 "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
             }
         },


### PR DESCRIPTION
Issues with a handful of websites were resolved with changes in `brave-core`. This PR re-enables the list by default on Nightly as per discussion on https://bravesoftware.slack.com/archives/C6YNM6Y5S/p1654120574558859?thread_ts=1654117214.714209&cid=C6YNM6Y5S