### PR TITLE
Disable Blob partitioning until opaque origins fixed.

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -355,6 +355,25 @@
           }
         },
         {
+          "name": "DisableBlobPartitioning",
+          "experiments": [
+              {
+                  "name": "Default",
+                  "probability_weight": 100,
+                  "feature_association": {
+                      "disable_feature": [
+                          "BravePartitionBlobStorage"
+                      ]
+                  }
+              }
+          ],
+          "filter": {
+              "min_version": "100.1.39.41",
+              "channel": ["NIGHTLY", "BETA", "RELEASE"],
+              "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
+          }
+        },
+        {
             "name": "SpeedreaderReleaseStudy",
             "experiments": [
                 {


### PR DESCRIPTION
Blobs from opaque origins doesn't work well with partitioning right now. Need to fix this. Until then disable the feature.

https://github.com/brave/brave-browser/issues/23171