### PR TITLE
Enable partitioned blobs on 1.39.118+.

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -313,6 +313,7 @@
           ],
           "filter": {
               "min_version": "100.1.39.41",
+              "max_version": "102.1.39.117",
               "channel": ["NIGHTLY", "BETA", "RELEASE"],
               "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
           }


### PR DESCRIPTION
Limiting the study that disables `BravePartitionBlobStorage` feature to max version `1.39.117`, because `1.39.118` is fixed as per https://github.com/brave/brave-browser/issues/23171#issuecomment-1148709728