### PR TITLE
EarlyBodyLoadCompat to nightly 100%

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1104,6 +1104,26 @@
                 "platform": ["WINDOWS", "MAC", "LINUX"],
                 "channel": ["RELEASE"]
             }
+        },
+        {
+            "name": "EarlyBodyLoadCompat",
+            "experiments": [
+                {
+                    "name": "Disabled",
+                    "probability_weight": 100,
+                    "feature_association": {
+                        "disable_feature": ["EarlyBodyLoad"]
+                    }
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+             ],
+            "filter": {
+                "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"],
+                "channel": ["NIGHTLY"]
+            }
         }
     ]
 }


### PR DESCRIPTION
For https://github.com/brave/brave-browser/issues/23267

PR is created in advance to solve the issues to page loading. I suppose that disabling the feature should helps, but it's unsafe to switch it for the all the users. Therefore, the current PR disables the feature only for nightly users.

We still need more confirmations that it helps before merging.