### PR TITLE
Enabling NavigationThreadingOptimizations: BETA 50%, STABLE 5%

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1071,16 +1071,18 @@
             "experiments": [
                 {
                     "name": "Disabled",
-                    "probability_weight": 100,
+                    "probability_weight": 50,
                     "feature_association": {
-                        "disable_feature": ["NavigationThreadingOptimizations"]
+                        "disable_feature": [
+                            "NavigationThreadingOptimizations"
+                        ]
                     }
                 },
                 {
                     "name": "Default",
-                    "probability_weight": 0
+                    "probability_weight": 50
                 }
-             ],
+            ],
             "filter": {
                 "platform": ["WINDOWS", "MAC", "LINUX"],
                 "channel": ["BETA"]
@@ -1091,19 +1093,45 @@
             "experiments": [
                 {
                     "name": "Disabled",
+                    "probability_weight": 95,
+                    "feature_association": {
+                        "disable_feature": [
+                            "NavigationThreadingOptimizations"
+                        ]
+                    }
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 5
+                }
+            ],
+            "filter": {
+                "platform": ["WINDOWS", "MAC", "LINUX"],
+                "channel": ["RELEASE"],
+                "min_version": "102.1.39.0"
+            }
+        },
+        {
+            "name": "NavigationThreadingOptimizationsCompatOldVersions",
+            "experiments": [
+                {
+                    "name": "Disabled",
                     "probability_weight": 100,
                     "feature_association": {
-                        "disable_feature": ["NavigationThreadingOptimizations"]
+                        "disable_feature": [
+                            "NavigationThreadingOptimizations"
+                        ]
                     }
                 },
                 {
                     "name": "Default",
                     "probability_weight": 0
                 }
-             ],
+            ],
             "filter": {
                 "platform": ["WINDOWS", "MAC", "LINUX"],
-                "channel": ["RELEASE"]
+                "channel": ["RELEASE"],
+                "max_version": "102.1.39.0"
             }
         }
     ]


### PR DESCRIPTION
For https://github.com/brave/brave-browser/issues/23267

Now we have 3 non-overlapping groups:
Two `NavigationThreadingOptimizationsCompat`: one for BETA (50%/50%) and one of new STABLE >=cr102 (5%/95%). We will remove all these group in the next few days to make the feature be in the default (enabled) state.

The last one is`NavigationThreadingOptimizationsCompatOldVersions`: a group for old clients (<cr102) to continue disabling the feature for them (because of a bug with navigations/localStorage). This group will stay in the config for some long period of time (~one year).
