### PR TITLE
NTP SI User Activity

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -382,12 +382,16 @@
             "name": "BraveAds.UserActivityStudy",
             "experiments": [
                 {
-                    "name": "Triggers=EMPTY/Threshold=0.0/IdleTimeThreshold=5",
+                    "name": "Triggers=NTPSI/TimeWindow=15m/Threshold=0.0/IdleTimeThreshold=5s",
                     "probability_weight": 100,
                     "parameters": [
                         {
                             "name": "triggers",
-                            "value": ""
+                            "value": "0D0B14110D0B14110D0B14110D0B1411=-1.0;0D0B1411070707=-1.0;07070707=-1.0"
+                        },
+                        {
+                            "name": "time_window",
+                            "value": "15m"
                         },
                         {
                             "name": "threshold",


### PR DESCRIPTION
This change will help prevent bad actors from seeing ads for a rolling 15 minutes time window if they trigger the following actions:

- Open four or more new tabs in succession (worth -1 point)
- Open a new tab and refresh that tab three or more times in succession (worth -1 point)
- Refresh the same tab four or more times in succession (worth -1 point)

The minimum threshold to view ads is set to 0 points.

Search for `Triggered event: ##` which will be followed by your current score, the minimum threshold to see ads and the rolling time window, i.e. `(-2:0:900 s)`. Your current score must be greater than or equal to the threshold to see ads.

The score is transient and will reset to 0 when restarting the browser.

Note: User Activity has been tested over many browser versions and is not a new feature.