### PR TITLE
Remove flag to enable native cosmetic filtering version

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -114,34 +114,6 @@
             }
         },
         {
-            "name": "NativeCosmeticFilteringStudy",
-            "experiments": [
-                {
-                    "name": "Enabled",
-                    "probability_weight": 100,
-                    "feature_association": {
-                        "enable_feature": ["BraveAdblockCosmeticFilteringNative"]
-                    }
-                },
-                {
-                    "name": "Disabled",
-                    "probability_weight": 0,
-                    "feature_association": {
-                        "disable_feature": ["BraveAdblockCosmeticFilteringNative"]
-                    }
-                },
-                {
-                    "name": "Default",
-                    "probability_weight": 0
-                }
-            ],
-            "filter": {
-                "min_version": "91.1.26.74",
-                "channel": ["NIGHTLY", "BETA", "RELEASE"],
-                "platform": ["WINDOWS", "MAC", "LINUX"]
-            }
-        },
-        {
             "name": "VulkanStudy",
             "experiments": [
                 {


### PR DESCRIPTION
The `BraveAdblockCosmeticFilteringNative` feature was removed with https://github.com/brave/brave-core/pull/9995 which landed in 1.31.x, so `NativeCosmeticFilteringStudy` is a no-op on 1.31.x and up.