### PR TITLE
Translate to BETA 100%

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1264,7 +1264,7 @@
             ],
             "filter": {
                 "min_version": "103.1.43.9",
-                "channel": ["NIGHTLY"],
+                "channel": ["NIGHTLY", "BETA"],
                 "platform": ["WINDOWS", "MAC", "LINUX"]
             }
         }


### PR DESCRIPTION
This was attempted with https://github.com/brave/brave-variations/pull/326 but that unintentionally updated `BraveRewardsWebUiPanelStudy` to BETA and not `BraveTranslateStudy`

This updates `BraveTranslateStudy` to BETA

Fixes https://github.com/brave/brave-browser/issues/24471