### PR TITLE
Push Cookie-List opt-in bubble to Nightly

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1211,6 +1211,27 @@
                 "channel": ["NIGHTLY", "BETA"],
                 "platform": ["WINDOWS", "MAC", "LINUX"]
             }
+        },
+        {
+            "name": "BraveAdblockCookieListOptInStudy",
+            "experiments": [
+                {
+                    "name": "Enabled",
+                    "probability_weight": 100,
+                    "feature_association": {
+                        "enable_feature": ["BraveAdblockCookieListOptIn"]
+                    }
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "min_version": "104.1.44.25",
+                "channel": ["NIGHTLY"],
+                "platform": ["WINDOWS", "MAC", "LINUX"]
+            }
         }
     ]
 }


### PR DESCRIPTION
Enables the "Cookie List" opt-in bubble on Nightly, which invites the user to enable the "Cookie List" adblock filter to hide cookie consent notices.