### PR TITLE
Android translate to BETA 100%

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1247,14 +1247,7 @@
                     "name": "Enabled",
                     "probability_weight": 100,
                     "feature_association": {
-                        "enable_feature": ["UseBraveTranslateGo"]
-                    }
-                },
-                {
-                    "name": "Disabled",
-                    "probability_weight": 0,
-                    "feature_association": {
-                        "disable_feature": ["UseBraveTranslateGo"]
+                        "enable_feature": ["UseBraveTranslateGo", "Translate"]
                     }
                 },
                 {
@@ -1263,38 +1256,10 @@
                 }
             ],
             "filter": {
-                "min_version": "103.1.43.9",
+                "min_version": "104.1.43.54",
                 "channel": ["NIGHTLY", "BETA"],
-                "platform": ["WINDOWS", "MAC", "LINUX"]
+                "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
             }
-        },
-        {
-          "name": "BraveTranslateAndroidStudy",
-          "experiments": [
-              {
-                  "name": "Enabled",
-                  "probability_weight": 100,
-                  "feature_association": {
-                      "enable_feature": ["UseBraveTranslateGo", "Translate"]
-                  }
-              },
-              {
-                  "name": "Disabled",
-                  "probability_weight": 0,
-                  "feature_association": {
-                      "disable_feature": ["UseBraveTranslateGo", "Translate"]
-                  }
-              },
-              {
-                  "name": "Default",
-                  "probability_weight": 0
-              }
-          ],
-          "filter": {
-              "min_version": "104.1.43.74",
-              "channel": ["NIGHTLY"],
-              "platform": ["ANDROID"]
-          }
-        }
+      }
     ]
 }


### PR DESCRIPTION
Resolves https://github.com/brave/brave-variations/issues/338

The PR enables translate in Android beta and merge desktop and Android studies into the one. 

The following things have done to support merging:
1. Min version was bumped to "104.1.43.54" (we need https://github.com/brave/brave-browser/issues/23770) It covers beta/nightly builds not older than 3 weeks ago. IMHO it's okay: we shouldn't about older non-stable installations. 
[The proof that 1.43.54 has the commit](https://user-images.githubusercontent.com/45488748/186644504-b25da4b2-cc8a-4e16-ac6c-b41ad6044aff.png)

2. Group "Disabled" was removed (because "probability_weight": 0 and we can't explicitly disable `Translate` feature for desktops);

3. Explicitly enabling `Translate` feature is added. It is enabled by default for Desktop([link](https://github.com/chromium/chromium/blob/main/components/translate/core/browser/translate_prefs.cc#L180)), but not for Android ([link](https://github.com/brave/brave-core/blob/master/chromium_src/components/translate/core/browser/translate_prefs.cc#L22)).

The next step is enable both desktop/android in release: https://github.com/brave/brave-variations/issues/335


