### PR TITLE
Limit studies that already enabled in code to current beta version.

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -311,6 +311,7 @@
             ],
             "filter": {
                 "min_version": "90.1.25.57",
+                "max_version": "104.1.43.79",
                 "channel": ["NIGHTLY", "BETA"],
                 "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
             }
@@ -339,6 +340,7 @@
             ],
             "filter": {
                 "min_version": "90.1.25.57",
+                "max_version": "104.1.43.79",
                 "channel": ["RELEASE"],
                 "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
             }
@@ -363,26 +365,7 @@
           ],
           "filter": {
               "min_version": "101.1.38.109",
-              "channel": ["NIGHTLY", "BETA", "RELEASE"],
-              "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
-          }
-        },
-        {
-          "name": "DisableBlobPartitioning",
-          "experiments": [
-              {
-                  "name": "Default",
-                  "probability_weight": 100,
-                  "feature_association": {
-                      "disable_feature": [
-                          "BravePartitionBlobStorage"
-                      ]
-                  }
-              }
-          ],
-          "filter": {
-              "min_version": "100.1.39.41",
-              "max_version": "102.1.39.117",
+              "max_version": "104.1.43.79",
               "channel": ["NIGHTLY", "BETA", "RELEASE"],
               "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
           }
@@ -991,6 +974,7 @@
             ],
             "filter": {
                 "min_version": "94.1.31.51",
+                "max_version": "104.1.43.79",
                 "channel": ["NIGHTLY", "BETA"],
                 "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
             }
@@ -1041,6 +1025,7 @@
             ],
             "filter": {
                 "min_version": "96.1.34.20",
+                "max_version": "104.1.43.79",
                 "channel": ["NIGHTLY", "BETA", "RELEASE"],
                 "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
             }
@@ -1070,6 +1055,7 @@
             ],
             "filter": {
                 "min_version": "96.1.34.4",
+                "max_version": "104.1.43.79",
                 "channel": ["NIGHTLY", "BETA", "RELEASE"],
                 "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
             }


### PR DESCRIPTION
These features are all enabled in code, so limiting these studies to the current "beta" to remove it from the seed when `max_version` will be phased out.
https://github.com/brave/brave-browser/issues/24148