### PR TITLE
enable BraveAdblockCookieListOptIn on release channel at 10% [`production`]

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1292,6 +1292,27 @@
             }
         },
         {
+            "name": "BraveAdblockCookieListOptInReleaseStudy",
+            "experiments": [
+                {
+                    "name": "Enabled",
+                    "probability_weight": 10,
+                    "feature_association": {
+                        "enable_feature": ["BraveAdblockCookieListOptIn"]
+                    }
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 90
+                }
+            ],
+            "filter": {
+                "min_version": "104.1.44.25",
+                "channel": ["RELEASE"],
+                "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
+            }
+        },
+        {
             "name": "AllowCertainClientHintsStudy",
             "experiments": [
                 {


### PR DESCRIPTION
`main`: https://github.com/brave/brave-variations/pull/407