### PR TITLE
Add fieldtrial-testing-config generator

### DIFF
--- a/seed/requirements.txt
+++ b/seed/requirements.txt
@@ -1,3 +1,5 @@
+argparse==1.2.1
 ecdsa>=0.17.0
 protobuf<4
+packaging>=20.0
 pycodestyle>=2.8.0

--- a/seed/serialize.py
+++ b/seed/serialize.py
@@ -217,7 +217,6 @@ if __name__ == "__main__":
     parser.add_argument('seed_path', help='json seed file to process')
     parser.add_argument(
       '--fieldtrial-testing-config-path', type=str,
-      default='fieldtrial_testing_config.json',
       help='Generate the most probable config and save to the provided path'
            'See src/testing/variations/README.md for details')
     parser.add_argument(


### PR DESCRIPTION
For https://github.com/brave/brave-variations/issues/409
See the issue for the description.

Usage example:
```python3 seed/serialize.py seed/seed.json --fieldtrial-testing-config-path=/Users/mikhail/work/brave-browser2/src/testing/variations/fieldtrial_testing_config.json` --target-version=106.1.45.37 --target-channel=NIGHTLY```