### PR TITLE
enable BraveAdblockCookieListOptIn on release channel at 25% [`production`]

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1260,14 +1260,14 @@
             "experiments": [
                 {
                     "name": "Enabled",
-                    "probability_weight": 10,
+                    "probability_weight": 25,
                     "feature_association": {
                         "enable_feature": ["BraveAdblockCookieListOptIn"]
                     }
                 },
                 {
                     "name": "Default",
-                    "probability_weight": 90
+                    "probability_weight": 75
                 }
             ],
             "filter": {


### PR DESCRIPTION
followup to https://github.com/brave/brave-variations/pull/408