### PR TITLE
enable BraveAdblockCookieListOptIn on release channel at 50% [`production`]

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1261,14 +1261,14 @@
             "experiments": [
                 {
                     "name": "Enabled",
-                    "probability_weight": 25,
+                    "probability_weight": 50,
                     "feature_association": {
                         "enable_feature": ["BraveAdblockCookieListOptIn"]
                     }
                 },
                 {
                     "name": "Default",
-                    "probability_weight": 75
+                    "probability_weight": 50
                 }
             ],
             "filter": {


### PR DESCRIPTION
followup to https://github.com/brave/brave-variations/pull/414