### PR TITLE
enable BraveAdblockCookieListOptIn on release channel at 50% [`main`]

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1128,14 +1128,14 @@
             "experiments": [
                 {
                     "name": "Enabled",
-                    "probability_weight": 10,
+                    "probability_weight": 50,
                     "feature_association": {
                         "enable_feature": ["BraveAdblockCookieListOptIn"]
                     }
                 },
                 {
                     "name": "Default",
-                    "probability_weight": 90
+                    "probability_weight": 50
                 }
             ],
             "filter": {


### PR DESCRIPTION
`production`: https://github.com/brave/brave-variations/pull/417