### PR TITLE
enable BraveAdblockCookieListOptIn on release channel at 100% [`main`]

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1128,14 +1128,14 @@
             "experiments": [
                 {
                     "name": "Enabled",
-                    "probability_weight": 50,
+                    "probability_weight": 100,
                     "feature_association": {
                         "enable_feature": ["BraveAdblockCookieListOptIn"]
                     }
                 },
                 {
                     "name": "Default",
-                    "probability_weight": 50
+                    "probability_weight": 0
                 }
             ],
             "filter": {


### PR DESCRIPTION
`production`: https://github.com/brave/brave-variations/pull/423