### PR TITLE
Split EnableCrashReportingOnAndroid

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1257,7 +1257,7 @@
             }
         },
         {
-            "name": "EnableCrashReportingOnAndroid",
+            "name": "MetricsAndCrashSampling",
             "experiments": [
                 {
                     "name": "Enabled",
@@ -1265,6 +1265,27 @@
                     "feature_association": {
                         "enable_feature": [
                             "MetricsReporting",
+                        ]
+                    }
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "channel": ["NIGHTLY", "BETA", "RELEASE"],
+                "platform": ["ANDROID"]
+            }
+        },
+        {
+            "name": "PostFREFixMetricsAndCrashSampling",
+            "experiments": [
+                {
+                    "name": "Enabled",
+                    "probability_weight": 100,
+                    "feature_association": {
+                        "enable_feature": [
                             "PostFREFixMetricsReporting"
                         ]
                     }


### PR DESCRIPTION
Resolves brave/brave-variations#424

Test plan:
1. Take Android Brave browser of Stable channel
2. Ensure you see crash with STR at 
https://github.com/brave/brave-browser/issues/26522
3. Uninstall app
4. Enable staging service with 
```
adb shell "echo 'https://variations.bravesoftware.com/seed' > /data/local/tmp/brave-test-variations-server-url"
```
5. Ensure that there is no crash with STR at 
https://github.com/brave/brave-browser/issues/26522

6. Sanity check: ensure crash reports are still sent by 
- go to Settings => Brave Shields & privacy => Automatically send diagnostics reports must be switched on
- paste url brave://inducebrowsercrashforrealz/ to new tab to simulate crash; if it will not crashed, press right arrow on screen keyboard
- launch browser after crash
- open brave://crashes, ensure the recent crash report is in the list, but status is Not uploaded and there is no Uploaded Crash Report ID
