### PR TITLE
Enable BraveVPN for Windows/macOS 100% (staging)

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1860,6 +1860,37 @@
                 ]
             },
             "name": "BraveHttpsByDefaultRolloutStudy"
+        },
+        {
+            "experiments": [
+                {
+                    "name": "Enabled",
+                    "probability_weight": 100,
+                    "feature_association": {
+                        "enable_feature": [
+                            "BraveVPN",
+                            "BraveVPNLinkSubscriptionAndroidUI"
+                        ]
+                    }
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "channel": [
+                    "NIGHTLY",
+                    "BETA",
+                    "RELEASE"
+                ],
+                "platform": [
+                    "WINDOWS",
+                    "MAC",
+                    "ANDROID"
+                ]
+            },
+            "name": "CrossPlatformVPNStudy"
         }
     ],
     "version": "1"


### PR DESCRIPTION
Enable `BraveVPN` feature on Windows and macOS (brave://flags/#brave-vpn)

Enables for STAGING brave-variation servers

Addresses https://github.com/brave/brave-browser/issues/25680