### PR TITLE
Make a dedicated script fieldtrial_testing_config generation

### DIFF
--- a/seed/fieldtrials_testing_config_generator.py
+++ b/seed/fieldtrials_testing_config_generator.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# Copyright (c) 2022 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
 """Generate the most probable testing config in chromium format
 
 For a single study the experiment with maximum probability_weight will be
@@ -11,6 +15,7 @@ Filters that will be processed by chromium code later: platforms
 The format description:
 https://chromium.googlesource.com/chromium/src/+/master/testing/variations/README.md
 """
+
 import serialize
 import json
 import proto.study_pb2 as study_pb2

--- a/seed/fieldtrials_testing_config_generator.py
+++ b/seed/fieldtrials_testing_config_generator.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Generate the most probable testing config in chromium format
+
+For a single study the experiment with maximum probability_weight will be
+chosen (the first one in the list if there are many of them).
+
+Filters that are processed here: min_version, max_version, channel.
+Filters to be ignored: min_os_version, county.
+Filters that will be processed by chromium code later: platforms
+
+The format description:
+https://chromium.googlesource.com/chromium/src/+/master/testing/variations/README.md
+"""
+import serialize
+import json
+import proto.study_pb2 as study_pb2
+import subprocess
+import sys
+import proto.variations_seed_pb2 as variations_seed_pb2
+import argparse
+from packaging import version
+
+
+PLATFORM_NAMES = {
+    study_pb2.Study.Platform.PLATFORM_WINDOWS: 'windows',
+    study_pb2.Study.Platform.PLATFORM_MAC: 'mac',
+    study_pb2.Study.Platform.PLATFORM_LINUX: 'linux',
+    study_pb2.Study.Platform.PLATFORM_IOS: 'ios',
+    study_pb2.Study.Platform.PLATFORM_ANDROID: 'android'
+}
+
+def _get_variations_revision(date: str, branch: str) -> str:
+    args =['git', 'rev-list', '-n', '1', '--first-parent']
+    if date:
+      args.append(f'--before={date}')
+    args.append(f'origin/{branch}')
+    output = subprocess.check_output(args)
+    return output.rstrip().decode('utf-8')
+
+
+def _get_seed_data(seed_git_path: str, variations_revision: str):
+  seed_string = subprocess.check_output(
+      ['git', 'show', f'{variations_revision}:{seed_git_path}'])
+  return json.loads(seed_string)
+
+
+def make_field_trial_testing_config(seed, version_string, channel_string):
+    target_version = version.parse(version_string)
+    target_channel = serialize.SUPPORTED_CHANNELS[channel_string]
+    config = {}
+    for study in seed.study:
+        json_study = {}
+        if (study.filter.min_version and
+            target_version < version.parse(study.filter.min_version)):
+            print('skip ' + study.name + ' because of min_version')
+            continue
+        if (study.filter.max_version and
+            target_version > version.parse(study.filter.max_version)):
+            print('skip ' + study.name + ' because of max_version')
+            continue
+        if study.filter.channel and not target_channel in study.filter.channel:
+            print('skip ' + study.name + ' because of channel')
+            continue
+
+        if study.filter.platform:
+            json_study['platforms'] = \
+              [PLATFORM_NAMES[x] for x in study.filter.platform]
+
+        # Find an experiment with max probability_weight:
+        best_experiment = max(
+            study.experiment, key=lambda x: x.probability_weight)
+
+        study_number = str(len(config) + 1)
+        experiments_json = {}
+        experiments_json['name'] = 'e' + study_number
+        experiments_json['full_name'] = best_experiment.name
+
+        params_json = {}
+        for param in best_experiment.param:
+            params_json[param.name] = param.value
+        if params_json:
+            experiments_json['params'] = params_json
+
+        enable_features = best_experiment.feature_association.enable_feature
+        if enable_features:
+            experiments_json['enable_features'] = [x for x in enable_features]
+
+        disable_features = best_experiment.feature_association.disable_feature
+        if disable_features:
+            experiments_json['disable_features'] = [x for x in disable_features]
+
+        json_study['experiments'] = [experiments_json]
+        json_study['full_name'] = study.name
+
+        config['s' + study_number] = [json_study]
+    return config
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+      'seed_path', type=argparse.FileType('r'), nargs='?',
+      default='seed/seed.json', help='json seed file to process')
+    parser.add_argument(
+      '-o', '--output', type=argparse.FileType('w'), required=True,
+      help='The path to write fieldtrial_testing_config.json'
+           'See src/testing/variations/README.md for details')
+    parser.add_argument(
+      '-ver', '--target-version', type=str, required=True,
+      help='The browser version in format [chrome_major].[brave_version]'
+           '(used to process filters)')
+    parser.add_argument(
+      '-c', '--target-channel', type=str, required=True,
+      choices=serialize.SUPPORTED_CHANNELS.keys(),
+      help='The browser channel (used to process filters)')
+    parser.add_argument(
+      '-d', '--target-date', type=str,
+      help=('Take version seed_path on a specific date.'
+            '"Format: "2022-09-09 10:02:27 +0000"'))
+    parser.add_argument(
+      '-b', '--target-branch', type=str, default='production',
+      help='target brave-variations branch to build config')
+    args = parser.parse_args()
+
+    revision = _get_variations_revision(args.target_date, args.target_branch)
+    print("Load", args.seed_path.name, 'at', revision)
+    seed_data = _get_seed_data(args.seed_path.name, revision)
+
+    print("Validate seed data")
+    if not serialize.validate(seed_data):
+        print("Seed data is invalid")
+        return -1
+    seed_message = serialize.make_variations_seed_message(seed_data)
+    json_config = make_field_trial_testing_config(
+        seed_message, args.target_version, args.target_channel)
+    json.dump(json_config, args.output,
+        indent=2)
+    print("Testing config saved to", args.output.name)
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/seed/fieldtrials_testing_config_generator.py
+++ b/seed/fieldtrials_testing_config_generator.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2022 The Brave Authors. All rights reserved.
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
-# you can obtain one at http://mozilla.org/MPL/2.0/.
+# you can obtain one at https://mozilla.org/MPL/2.0/.
 """Generate the most probable testing config in chromium format
 
 For a single study the experiment with maximum probability_weight will be

--- a/seed/fieldtrials_testing_config_generator.py
+++ b/seed/fieldtrials_testing_config_generator.py
@@ -39,9 +39,9 @@ def _get_variations_revision(date: str, branch: str) -> str:
 
 
 def _get_seed_data(seed_git_path: str, variations_revision: str):
-  seed_string = subprocess.check_output(
-      ['git', 'show', f'{variations_revision}:{seed_git_path}'])
-  return json.loads(seed_string)
+    seed_string = subprocess.check_output(
+        ['git', 'show', f'{variations_revision}:{seed_git_path}'])
+    return json.loads(seed_string)
 
 
 def make_field_trial_testing_config(seed, version_string, channel_string):
@@ -133,8 +133,7 @@ def main():
     seed_message = serialize.make_variations_seed_message(seed_data)
     json_config = make_field_trial_testing_config(
         seed_message, args.target_version, args.target_channel)
-    json.dump(json_config, args.output,
-        indent=2)
+    json.dump(json_config, args.output, indent=2)
     print("Testing config saved to", args.output.name)
     return 0
 

--- a/seed/serialize.py
+++ b/seed/serialize.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# Copyright (c) 2022 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import datetime
 import hashlib

--- a/seed/serialize.py
+++ b/seed/serialize.py
@@ -2,13 +2,12 @@
 
 import datetime
 import hashlib
+import sys
 import json
 import proto.study_pb2 as study_pb2
 import time
-import sys
 import proto.variations_seed_pb2 as variations_seed_pb2
 import argparse
-from packaging import version
 
 SEED_BIN_PATH = "./seed.bin"
 SERIALNUMBER_PATH = "./serialnumber"
@@ -22,15 +21,6 @@ SUPPORTED_CHANNELS = {
     'BETA': study_pb2.Study.Channel.BETA,
     'RELEASE': study_pb2.Study.Channel.STABLE
 }
-
-PLATFORM_NAMES = {
-    study_pb2.Study.Platform.PLATFORM_WINDOWS: 'windows',
-    study_pb2.Study.Platform.PLATFORM_MAC: 'mac',
-    study_pb2.Study.Platform.PLATFORM_LINUX: 'linux',
-    study_pb2.Study.Platform.PLATFORM_IOS: 'ios',
-    study_pb2.Study.Platform.PLATFORM_ANDROID: 'android'
-}
-
 
 def validate(seed):
     for study in seed['studies']:
@@ -79,7 +69,6 @@ def make_variations_seed_message(seed_data):
     seed.version = seed_data['version']
     serialnumber = get_serial_number()
     seed.serial_number = serialnumber
-    update_serial_number(serialnumber)
 
     for study_data in seed_data['studies']:
         study = seed.study.add()
@@ -139,107 +128,28 @@ def make_variations_seed_message(seed_data):
     return seed
 
 
-def make_field_trial_testing_config(seed, version_string, channel_string):
-    """Generate the most probable testing config in chromium format
-
-    For a single study the experiment with maximum probability_weight will be
-    chosen (the first one in the list if there are many of them).
-
-    Filters that are processed here: min/max_version, channel.
-    Filters to be ignored: min_os_version, county.
-    Filters that will be processed by chromium code later: platforms
-
-    The format description:
-    https://chromium.googlesource.com/chromium/src/+/master/testing/variations/README.md
-    """
-    target_version = version.parse(version_string)
-    target_channel = SUPPORTED_CHANNELS[channel_string]
-    config = {}
-    for study in seed.study:
-        json_study = {}
-        if (study.filter.min_version and
-            target_version < version.parse(study.filter.min_version)):
-            print('skip ' + study.name + ' because of min_version')
-            continue
-        if (study.filter.max_version and
-            target_version > version.parse(study.filter.max_version)):
-            print('skip ' + study.name + ' because of max_version')
-            continue
-        if study.filter.channel and not target_channel in study.filter.channel:
-            print('skip ' + study.name + ' because of channel')
-            continue
-
-        if study.filter.platform:
-            json_study['platforms'] = \
-              [PLATFORM_NAMES[x] for x in study.filter.platform]
-
-        # Find an experiment with max probability_weight:
-        best_experiment = max(
-            study.experiment, key=lambda x: x.probability_weight)
-
-        study_number = str(len(config) + 1)
-        experiments_json = {}
-        experiments_json['name'] = 'e' + study_number
-        experiments_json['full_name'] = best_experiment.name
-
-        params_json = {}
-        for param in best_experiment.param:
-            params_json[param.name] = param.value
-        if params_json:
-            experiments_json['params'] = params_json
-
-        enable_features = best_experiment.feature_association.enable_feature
-        if enable_features:
-            experiments_json['enable_features'] = [x for x in enable_features]
-
-        disable_features = best_experiment.feature_association.disable_feature
-        if disable_features:
-            experiments_json['disable_features'] = [x for x in disable_features]
-
-        json_study['experiments'] = [experiments_json]
-        json_study['full_name'] = study.name
-
-        config['s' + study_number] = [json_study]
-    return config
-
-
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-      'seed_path', type=argparse.FileType('r'), nargs='?', default=sys.stdin,
-      help='json seed file to process (skip it to use stdin)')
-    parser.add_argument(
-      '--fieldtrial-testing-config-path', type=argparse.FileType('w'),
-      help='Generate the most probable config and save to the provided path'
-           'See src/testing/variations/README.md for details')
-    parser.add_argument(
-      '--target-version', type=str,
-      help='The browser version in format [chrome_major].[brave_version]'
-           '(used to process filters)')
-    parser.add_argument(
-      '--target-channel', type=str, choices=SUPPORTED_CHANNELS.keys(),
-      help='The browser channel (used to process filters)')
-
+      'seed_path', type=argparse.FileType('r'), nargs='?',
+      help='json seed file to process')
     args = parser.parse_args()
 
     print("Load", args.seed_path.name)
     seed_data = json.load(args.seed_path)
 
     print("Validate seed data")
-    if validate(seed_data):
-        seed_message = make_variations_seed_message(seed_data)
-        if args.fieldtrial_testing_config_path:
-            json_config = make_field_trial_testing_config(
-                seed_message, args.target_version, args.target_channel)
-            json.dump(json_config, args.fieldtrial_testing_config_path,
-                      indent=2)
-            print("Testing config saved to",
-                  args.fieldtrial_testing_config_path.name)
-        else:
-            # Serialize and save as seed file
-            with open(SEED_BIN_PATH, "wb") as seed_file:
-                seed_file.write(seed_message.SerializeToString())
-            print("Seed data serialized and saved to ", SEED_BIN_PATH)
-
-    else:
+    if not validate(seed_data):
         print("Seed data is invalid")
+        return -1
+    seed_message = make_variations_seed_message(seed_data)
+    update_serial_number(seed_message.serial_number)
+
+    # Serialize and save as seed file
+    with open(SEED_BIN_PATH, "wb") as seed_file:
+        seed_file.write(seed_message.SerializeToString())
+    print("Seed data serialized and saved to ", SEED_BIN_PATH)
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/seed/serialize.py
+++ b/seed/serialize.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2022 The Brave Authors. All rights reserved.
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
-# you can obtain one at http://mozilla.org/MPL/2.0/.
+# you can obtain one at https://mozilla.org/MPL/2.0/.
 
 import datetime
 import hashlib


### PR DESCRIPTION
Resolves https://github.com/brave/brave-variations/issues/409

This PR moves the code about field trials generation to a dedicated .py file.
Also it adds support  trials generation for specific date/branch.

b-c PR: https://github.com/brave/brave-core/pull/16016