### PR TITLE
Limit already active studies to current beta version.

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -375,7 +375,7 @@
                     "NIGHTLY",
                     "BETA"
                 ],
-                "max_version": "110.1.49.83",
+                "max_version": "116.1.58.100",
                 "min_version": "90.1.25.57",
                 "platform": [
                     "WINDOWS",
@@ -415,7 +415,7 @@
                 "channel": [
                     "RELEASE"
                 ],
-                "max_version": "110.1.49.83",
+                "max_version": "116.1.58.100",
                 "min_version": "90.1.25.57",
                 "platform": [
                     "WINDOWS",
@@ -449,7 +449,7 @@
                     "BETA",
                     "RELEASE"
                 ],
-                "max_version": "110.1.49.83",
+                "max_version": "116.1.58.100",
                 "min_version": "101.1.38.109",
                 "platform": [
                     "WINDOWS",
@@ -932,7 +932,7 @@
                     "NIGHTLY",
                     "BETA"
                 ],
-                "max_version": "110.1.49.83",
+                "max_version": "116.1.58.100",
                 "min_version": "94.1.31.51",
                 "platform": [
                     "WINDOWS",
@@ -967,7 +967,7 @@
                 "channel": [
                     "RELEASE"
                 ],
-                "max_version": "110.1.49.83",
+                "max_version": "116.1.58.100",
                 "min_version": "94.1.31.51",
                 "platform": [
                     "WINDOWS",
@@ -1000,7 +1000,7 @@
                     "BETA",
                     "RELEASE"
                 ],
-                "max_version": "110.1.49.83",
+                "max_version": "116.1.58.100",
                 "min_version": "96.1.34.20",
                 "platform": [
                     "WINDOWS",
@@ -1039,7 +1039,7 @@
                     "BETA",
                     "RELEASE"
                 ],
-                "max_version": "110.1.49.83",
+                "max_version": "116.1.58.100",
                 "min_version": "96.1.34.4",
                 "platform": [
                     "WINDOWS",

--- a/seed/seed.json
+++ b/seed/seed.json
@@ -375,6 +375,7 @@
                     "NIGHTLY",
                     "BETA"
                 ],
+                "max_version": "110.1.49.83",
                 "min_version": "90.1.25.57",
                 "platform": [
                     "WINDOWS",
@@ -414,6 +415,7 @@
                 "channel": [
                     "RELEASE"
                 ],
+                "max_version": "110.1.49.83",
                 "min_version": "90.1.25.57",
                 "platform": [
                     "WINDOWS",
@@ -447,6 +449,7 @@
                     "BETA",
                     "RELEASE"
                 ],
+                "max_version": "110.1.49.83",
                 "min_version": "101.1.38.109",
                 "platform": [
                     "WINDOWS",
@@ -456,35 +459,6 @@
                 ]
             },
             "name": "FirstPartyEphemeralDomainBlockStudy"
-        },
-        {
-            "experiments": [
-                {
-                    "feature_association": {
-                        "disable_feature": [
-                            "BravePartitionBlobStorage"
-                        ]
-                    },
-                    "name": "Default",
-                    "probability_weight": 100
-                }
-            ],
-            "filter": {
-                "channel": [
-                    "NIGHTLY",
-                    "BETA",
-                    "RELEASE"
-                ],
-                "max_version": "102.1.39.117",
-                "min_version": "100.1.39.41",
-                "platform": [
-                    "WINDOWS",
-                    "MAC",
-                    "LINUX",
-                    "ANDROID"
-                ]
-            },
-            "name": "DisableBlobPartitioning"
         },
         {
             "experiments": [
@@ -958,6 +932,7 @@
                     "NIGHTLY",
                     "BETA"
                 ],
+                "max_version": "110.1.49.83",
                 "min_version": "94.1.31.51",
                 "platform": [
                     "WINDOWS",
@@ -992,6 +967,7 @@
                 "channel": [
                     "RELEASE"
                 ],
+                "max_version": "110.1.49.83",
                 "min_version": "94.1.31.51",
                 "platform": [
                     "WINDOWS",
@@ -1024,6 +1000,7 @@
                     "BETA",
                     "RELEASE"
                 ],
+                "max_version": "110.1.49.83",
                 "min_version": "96.1.34.20",
                 "platform": [
                     "WINDOWS",
@@ -1062,6 +1039,7 @@
                     "BETA",
                     "RELEASE"
                 ],
+                "max_version": "110.1.49.83",
                 "min_version": "96.1.34.4",
                 "platform": [
                     "WINDOWS",

--- a/seed/seed.json
+++ b/seed/seed.json
@@ -375,7 +375,7 @@
                     "NIGHTLY",
                     "BETA"
                 ],
-                "max_version": "116.1.58.100",
+                "max_version": "121.1.63.141",
                 "min_version": "90.1.25.57",
                 "platform": [
                     "WINDOWS",
@@ -415,7 +415,7 @@
                 "channel": [
                     "RELEASE"
                 ],
-                "max_version": "116.1.58.100",
+                "max_version": "121.1.63.141",
                 "min_version": "90.1.25.57",
                 "platform": [
                     "WINDOWS",
@@ -449,7 +449,7 @@
                     "BETA",
                     "RELEASE"
                 ],
-                "max_version": "116.1.58.100",
+                "max_version": "121.1.63.141",
                 "min_version": "101.1.38.109",
                 "platform": [
                     "WINDOWS",
@@ -932,7 +932,7 @@
                     "NIGHTLY",
                     "BETA"
                 ],
-                "max_version": "116.1.58.100",
+                "max_version": "121.1.63.141",
                 "min_version": "94.1.31.51",
                 "platform": [
                     "WINDOWS",
@@ -967,7 +967,7 @@
                 "channel": [
                     "RELEASE"
                 ],
-                "max_version": "116.1.58.100",
+                "max_version": "121.1.63.141",
                 "min_version": "94.1.31.51",
                 "platform": [
                     "WINDOWS",
@@ -1000,7 +1000,7 @@
                     "BETA",
                     "RELEASE"
                 ],
-                "max_version": "116.1.58.100",
+                "max_version": "121.1.63.141",
                 "min_version": "96.1.34.20",
                 "platform": [
                     "WINDOWS",
@@ -1039,7 +1039,7 @@
                     "BETA",
                     "RELEASE"
                 ],
-                "max_version": "116.1.58.100",
+                "max_version": "121.1.63.141",
                 "min_version": "96.1.34.4",
                 "platform": [
                     "WINDOWS",


### PR DESCRIPTION
Reapply limits from https://github.com/brave/brave-variations/pull/342 with the current beta version.

Resolves https://github.com/brave/brave-browser/issues/24148