### PR TITLE
Add .vpython3 for field trials generator

### DIFF
--- a/seed/fieldtrials_testing_config_generator.py
+++ b/seed/fieldtrials_testing_config_generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env vpython3
 # Copyright (c) 2022 The Brave Authors. All rights reserved.
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,

--- a/seed/fieldtrials_testing_config_generator.py.vpython3
+++ b/seed/fieldtrials_testing_config_generator.py.vpython3
@@ -1,0 +1,31 @@
+# Copyright (c) 2023 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# you can obtain one at https://mozilla.org/MPL/2.0/.
+
+python_version: "3.8"
+
+# google.protobuf
+wheel: <
+  name: "infra/python/wheels/protobuf-py2_py3"
+  version: "version:3.18.1"
+>
+wheel: <
+  name: "infra/python/wheels/packaging-py2_py3"
+  version: "version:16.8"
+>
+
+wheel <
+  name: "infra/python/wheels/six-py2_py3"
+  version: "version:1.15.0"
+>
+
+wheel: <
+  name: "infra/python/wheels/packaging-py2_py3"
+  version: "version:16.8"
+>
+
+wheel: <
+  name: "infra/python/wheels/pyparsing-py2_py3"
+  version: "version:2.4.7"
+>


### PR DESCRIPTION
.vpython specs allow to launch the script via vpython3 without installing necessary packages in advance.
For https://github.com/brave/brave-browser/issues/27864