### PR TITLE
Disable ads for pre Rewards 2.5 builds

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -514,6 +514,56 @@
                             "AdServing"
                         ]
                     },
+                    "name": "DisableAdsForLegacyBuilds",
+                    "parameters": [
+                        {
+                            "name": "maximum_ad_notifications_per_day",
+                            "value": "0"
+                        },
+                        {
+                            "name": "maximum_inline_content_ads_per_day",
+                            "value": "0"
+                        },
+                        {
+                            "name": "maximum_new_tab_page_ads_per_day",
+                            "value": "0"
+                        },
+                        {
+                            "name": "maximum_promoted_content_ads_per_day",
+                            "value": "0"
+                        },
+                        {
+                            "name": "maximum_search_result_ads_per_day",
+                            "value": "0"
+                        }
+                    ],    
+                    "probability_weight": 100
+                }
+            ],
+            "filter": {
+                "channel": [
+                    "RELEASE",
+                    "NIGHTLY",
+                    "BETA"
+                ],
+				"max_version": "109.1.48.60",
+                "platform": [
+                    "WINDOWS",
+                    "MAC",
+                    "LINUX",
+                    "ANDROID"
+                ]
+            },
+            "name": "AdServingStudy"
+        },
+        {
+            "experiments": [
+                {
+                    "feature_association": {
+                        "enable_feature": [
+                            "AdServing"
+                        ]
+                    },
                     "name": "DefaultAdNotificationsPerHour=10/MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=6/MaximumInlineContentAdsPerDay=20/AdServingVersion=1",
                     "parameters": [
                         {
@@ -575,6 +625,7 @@
                 "channel": [
                     "RELEASE"
                 ],
+				"min_version": "109.1.48.61",
                 "platform": [
                     "WINDOWS",
                     "MAC",
@@ -770,6 +821,7 @@
                     "NZ",
                     "GB"
                 ],
+				"min_version": "109.1.48.61",
                 "platform": [
                     "WINDOWS",
                     "MAC",


### PR DESCRIPTION
Ads should not be served on 109.1.48.60 or older
Ads should be served on 109.1.48.61 or newer