### PR TITLE
Enable BraveVPN for Windows/macOS/Android 5% (production)

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1991,6 +1991,37 @@
                 ]
             },
             "name": "BraveHttpsByDefaultRolloutStudy"
+        },
+        {
+            "experiments": [
+                {
+                    "name": "Enabled",
+                    "probability_weight": 5,
+                    "feature_association": {
+                        "enable_feature": [
+                            "BraveVPN",
+                            "BraveVPNLinkSubscriptionAndroidUI"
+                        ]
+                    }
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 95
+                }
+            ],
+            "filter": {
+                "channel": [
+                    "NIGHTLY",
+                    "BETA",
+                    "RELEASE"
+                ],
+                "platform": [
+                    "WINDOWS",
+                    "MAC",
+                    "ANDROID"
+                ]
+            },
+            "name": "CrossPlatformVPNStudy"
         }
     ],
     "version": "1"


### PR DESCRIPTION
Enable `BraveVPN` feature on **Windows**, **macOS**, and **Android** (brave://flags/#brave-vpn)

Enables for 5% of folks using PRODUCTION brave-variation servers

Addresses https://github.com/brave/brave-browser/issues/25680