### PR TITLE
Enable Google Sign In on Android Nightly as well

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -74,7 +74,8 @@
                 "platform": [
                     "WINDOWS",
                     "MAC",
-                    "LINUX"
+                    "LINUX",
+                    "ANDROID"
                 ]
             },
             "name": "BraveGoogleSignInPermissionStudy"


### PR DESCRIPTION
We previously enabled Google Sign In feature on Desktop Nightly in https://github.com/brave/brave-variations/pull/533 and https://github.com/brave/brave-variations/pull/534