### PR TITLE
Enable BraveVPN for Windows/macOS/Android 25% (production) 

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2035,7 +2035,7 @@
             "experiments": [
                 {
                     "name": "Enabled",
-                    "probability_weight": 5,
+                    "probability_weight": 25,
                     "feature_association": {
                         "enable_feature": [
                             "BraveVPN",
@@ -2045,7 +2045,7 @@
                 },
                 {
                     "name": "Default",
-                    "probability_weight": 95
+                    "probability_weight": 75
                 }
             ],
             "filter": {


### PR DESCRIPTION
Enable `BraveVPN` feature on **Windows**, **macOS**, and **Android** (brave://flags/#brave-vpn)

Enables for 25% of folks using PRODUCTION brave-variation servers

Addresses https://github.com/brave/brave-browser/issues/25680