### PR TITLE
Enable BraveVPN for Windows/macOS/Android 100% (production)

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2018,6 +2018,7 @@
                     "BETA",
                     "RELEASE"
                 ],
+                "min_version": "110.1.49.120",
                 "platform": [
                     "WINDOWS",
                     "MAC",

--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1999,7 +1999,7 @@
             "experiments": [
                 {
                     "name": "Enabled",
-                    "probability_weight": 50,
+                    "probability_weight": 100,
                     "feature_association": {
                         "enable_feature": [
                             "BraveVPN",
@@ -2009,7 +2009,7 @@
                 },
                 {
                     "name": "Default",
-                    "probability_weight": 50
+                    "probability_weight": 0
                 }
             ],
             "filter": {


### PR DESCRIPTION
Enable `BraveVPN` feature on **Windows**, **macOS**, and **Android** (brave://flags/#brave-vpn)

Enables for 100% of folks using PRODUCTION brave-variation servers

Fixes https://github.com/brave/brave-browser/issues/25680