### PR TITLE
Disable BraveCleanupSessionCookiesOnSessionRestore on MacOS.

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1775,6 +1775,31 @@
                 ]
             },
             "name": "CrossPlatformVPNStudy"
+        },
+        {
+            "experiments": [
+                {
+                    "feature_association": {
+                        "disable_feature": [
+                            "BraveCleanupSessionCookiesOnSessionRestore"
+                        ]
+                    },
+                    "name": "Disabled",
+                    "probability_weight": 100
+                }
+            ],
+            "filter": {
+                "channel": [
+                    "RELEASE",
+                    "BETA",
+                    "NIGHTLY"
+                ],
+                "min_version": "111.1.50.0",
+                "platform": [
+                    "MAC"
+                ]
+            },
+            "name": "BraveCleanupSessionCookiesOnSessionRestore"
         }
     ],
     "version": "1"


### PR DESCRIPTION
Brave restart after an update on MacOS doesn't work as expected. Because of this we cleanup session cookies when we shouldn't.

This PR restores the old behavior on MacOS until we fix the restart process.

https://github.com/brave/brave-browser/issues/29135