### PR TITLE
Enable BraveForgetFirstPartyStorage on nightly desktop.

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2133,6 +2133,44 @@
                 ]
             },
             "name": "ModuleFileNamePatchStudy"
+        },
+        {
+            "experiments": [
+                {
+                    "feature_association": {
+                        "enable_feature": [
+                            "BraveForgetFirstPartyStorage"
+                        ]
+                    },
+                    "name": "Enabled",
+                    "probability_weight": 100
+                },
+                {
+                    "feature_association": {
+                        "disable_feature": [
+                            "BraveForgetFirstPartyStorage"
+                        ]
+                    },
+                    "name": "Disabled",
+                    "probability_weight": 0
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "channel": [
+                    "NIGHTLY"
+                ],
+                "min_version": "112.1.51.57",
+                "platform": [
+                    "WINDOWS",
+                    "MAC",
+                    "LINUX"
+                ]
+            },
+            "name": "BraveForgetFirstPartyStorage"
         }
     ],
     "version": "1"


### PR DESCRIPTION
Enable core part in nightly builds for https://github.com/brave/brave-browser/issues/26465

This will add a new option to the Shields popup.
https://github.com/brave/brave-core/pull/18014#issuecomment-1505326910