### PR TITLE
Disable reset sync progress marker study; fixes #569. Uplift to production

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2125,6 +2125,47 @@
                 ]
             },
             "name": "SpeedreaderAndroidStudy"
+        },
+        {
+            "experiments": [
+                {
+                    "feature_association": {
+                        "enable_feature": [
+                            "ResetProgressMarkerOnCommitFailures"
+                        ]
+                    },
+                    "name": "Enabled",
+                    "probability_weight": 0
+                },
+                {
+                    "feature_association": {
+                        "disable_feature": [
+                            "ResetProgressMarkerOnCommitFailures"
+                        ]
+                    },
+                    "name": "Disabled",
+                    "probability_weight": 100
+
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "channel": [
+                    "NIGHTLY",
+                    "BETA",
+                    "RELEASE"
+                ],
+                "platform": [
+                    "WINDOWS",
+                    "MAC",
+                    "LINUX",
+                    "ANDROID"
+                ]
+            },
+            "name": "SyncResetProgressTokenStudy"
         }
     ],
     "version": "1"


### PR DESCRIPTION
This is uplift of https://github.com/brave/brave-variations/pull/570

Steps to verify the Griffin change is applied. This requires local modified build and hard to test with common available installers, because requires profile folder manipulation and it is not 100% reliable.

1. Make a local build with patch
```
--- a/components/sync/engine/brave_model_type_worker.cc
+++ b/components/sync/engine/brave_model_type_worker.cc
@@ -59,8 +59,10 @@ void BraveModelTypeWorker::OnCommitResponse(
                                     error_response_list);
 
   if (!base::FeatureList::IsEnabled(features::kBraveSyncResetProgressMarker)) {
+LOG(ERROR) << "[BraveSync] " << __func__ << " DISABLED kBraveSyncResetProgressMarker";
     return;
   }
+LOG(ERROR) << "[BraveSync] " << __func__ << " ENABLED kBraveSyncResetProgressMarker";
```
2. Launch own-built binary with args
```
./brave --user-data-dir=<your test data dir>   --enable-logging=stderr --v=0 \
         --variations-server-url=https://variations.bravesoftware.com/seed \
--variations-insecure-server-url=https://variations.bravesoftware.com/seed \
--vmodule=study_filtering=1 \
--fake-variations-channel=canary
```
3. Enable sync if not enabled and add some bookmark
4. Ensure you can see in log
```
brave_model_type_worker.cc(62)] [BraveSync] OnCommitResponse DISABLED kBraveSyncResetProgressMarker
```
