### PR TITLE
Enabled whatsnew study for 1.52 nightly

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1878,6 +1878,46 @@
         {
             "experiments": [
                 {
+                    "name": "Enabled",
+                    "parameters": [
+                        {
+                            "name": "target_major_version",
+                            "value": "1.52"
+                        }
+                    ],
+                    "probability_weight": 100
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "channel": [
+                    "NIGHTLY"
+                ],
+                "country": [
+                    "US",
+                    "GB",
+                    "DE",
+                    "FR",
+                    "ES",
+                    "JP",
+                    "KR",
+                    "PT",
+                    "CN"
+                ],
+                "platform": [
+                    "WINDOWS",
+                    "MAC",
+                    "LINUX"
+                ]
+            },
+            "name": "WhatsNewStudy"
+        },
+        {
+            "experiments": [
+                {
                     "feature_association": {
                         "enable_feature": [
                             "Speedreader"


### PR DESCRIPTION
With this study, existing nightly user will see https://brave.com/whats-new in new foreground tab after startup once.