### PR TITLE
Set NTP-SI ads per day to zero for May 5th to monitor metrics for non-opted-in users to use Eastern Time - Production

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -628,8 +628,8 @@
             "filter": {
                 "channel": [
                     "RELEASE",
-                    "NIGHTLY",
-                    "BETA"
+                    "BETA",
+                    "NIGHTLY"
                 ],
 				"max_version": "109.1.48.60",
                 "platform": [
@@ -678,8 +678,8 @@
             "filter": {
                 "channel": [
                     "RELEASE",
-                    "NIGHTLY",
-                    "BETA"
+                    "BETA",
+                    "NIGHTLY"
                 ],
 				"min_version": "109.1.48.61",
                 "platform": [
@@ -687,7 +687,115 @@
                     "MAC",
                     "LINUX",
                     "ANDROID"
-                ]
+                ],
+                "end_date" : 1683262799
+            },
+            "name": "BraveAds.AdServingStudy"
+        },
+        {
+            "experiments": [
+                {
+                    "feature_association": {
+                        "enable_feature": [
+                            "AdServing"
+                        ]
+                    },
+                    "name": "DefaultAdNotificationsPerHour=10/MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=6/MaximumInlineContentAdsPerDay=20/MaximumNewTabPageAdsPerDay=0/AdServingVersion=2",
+                    "parameters": [
+                        {
+                            "name": "default_ad_notifications_per_hour",
+                            "value": "10"
+                        },
+                        {
+                            "name": "maximum_ad_notifications_per_day",
+                            "value": "100"
+                        },
+                        {
+                            "name": "maximum_inline_content_ads_per_hour",
+                            "value": "6"
+                        },
+                        {
+                            "name": "maximum_inline_content_ads_per_day",
+                            "value": "20"
+                        },
+                        {
+                            "name": "maximum_new_tab_page_ads_per_day",
+                            "value": "0"
+                        },
+                        {
+                            "name": "ad_serving_version",
+                            "value": "2"
+                        }
+                    ],
+                    "probability_weight": 100
+                }
+            ],
+            "filter": {
+                "channel": [
+                    "RELEASE",
+                    "BETA",
+                    "NIGHTLY"
+                ],
+				"min_version": "109.1.48.61",
+                "platform": [
+                    "WINDOWS",
+                    "MAC",
+                    "LINUX",
+                    "ANDROID"
+                ],
+                "start_date" : 1683262800,
+                "end_date" : 1683349199
+            },
+            "name": "BraveAds.AdServingStudy"
+        },
+        {
+            "experiments": [
+                {
+                    "feature_association": {
+                        "enable_feature": [
+                            "AdServing"
+                        ]
+                    },
+                    "name": "DefaultAdNotificationsPerHour=10/MaximumAdNotificationsPerDay=100/MaximumInlineContentAdsPerHour=6/MaximumInlineContentAdsPerDay=20/AdServingVersion=2",
+                    "parameters": [
+                        {
+                            "name": "default_ad_notifications_per_hour",
+                            "value": "10"
+                        },
+                        {
+                            "name": "maximum_ad_notifications_per_day",
+                            "value": "100"
+                        },
+                        {
+                            "name": "maximum_inline_content_ads_per_hour",
+                            "value": "6"
+                        },
+                        {
+                            "name": "maximum_inline_content_ads_per_day",
+                            "value": "20"
+                        },
+                        {
+                            "name": "ad_serving_version",
+                            "value": "2"
+                        }
+                    ],
+                    "probability_weight": 100
+                }
+            ],
+            "filter": {
+                "channel": [
+                    "RELEASE",
+                    "BETA",
+                    "NIGHTLY"
+                ],
+				"min_version": "109.1.48.61",
+                "platform": [
+                    "WINDOWS",
+                    "MAC",
+                    "LINUX",
+                    "ANDROID"
+                ],
+                "start_date" : 1683349200
             },
             "name": "BraveAds.AdServingStudy"
         },


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-variations/pull/595