### PR TITLE
Re-enable reset sync progress marker feature

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1774,33 +1774,6 @@
             "name": "BraveForgetFirstPartyStorage"
         },
         {
-            "name": "SyncResetProgressTokenStudy",
-            "experiments": [
-                  {
-                      "name": "Enabled",
-                      "probability_weight": 0,
-                      "feature_association": {
-                          "enable_feature": ["ResetProgressMarkerOnCommitFailures"]
-                      }
-                  },
-                  {
-                      "name": "Disabled",
-                      "probability_weight": 100,
-                      "feature_association": {
-                          "disable_feature": ["ResetProgressMarkerOnCommitFailures"]
-                      }
-                  },
-                  {
-                      "name": "Default",
-                      "probability_weight": 0
-                  }
-            ],
-            "filter": {
-                "channel": ["NIGHTLY", "BETA", "RELEASE"],
-                "platform": ["WINDOWS", "MAC", "LINUX", "ANDROID"]
-            }
-        },
-        {
             "experiments": [
                 {
                     "feature_association": {


### PR DESCRIPTION
Resolves https://github.com/brave/brave-variations/issues/619

Basically this is revert of https://github.com/brave/brave-variations/pull/570