### PR TITLE
Re-enable reset sync progress marker feature (#620)

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2080,47 +2080,6 @@
         {
             "experiments": [
                 {
-                    "feature_association": {
-                        "enable_feature": [
-                            "ResetProgressMarkerOnCommitFailures"
-                        ]
-                    },
-                    "name": "Enabled",
-                    "probability_weight": 0
-                },
-                {
-                    "feature_association": {
-                        "disable_feature": [
-                            "ResetProgressMarkerOnCommitFailures"
-                        ]
-                    },
-                    "name": "Disabled",
-                    "probability_weight": 100
-
-                },
-                {
-                    "name": "Default",
-                    "probability_weight": 0
-                }
-            ],
-            "filter": {
-                "channel": [
-                    "NIGHTLY",
-                    "BETA",
-                    "RELEASE"
-                ],
-                "platform": [
-                    "WINDOWS",
-                    "MAC",
-                    "LINUX",
-                    "ANDROID"
-                ]
-            },
-            "name": "SyncResetProgressTokenStudy"
-        },
-        {
-            "experiments": [
-                {
                     "name": "Enabled",
                     "parameters": [
                         {


### PR DESCRIPTION
This is uplift of https://github.com/brave/brave-variations/pull/620 into production.

Test plan:
1. Launch browser with staging variation server, I used this command
```
/opt/brave.com/brave-nightly/brave  --user-data-dir=/home/alexey/.config/BraveSoftware/TEST/Nightly-Variations-B  \
 --enable-logging=stderr --v=0   --variations-server-url=https://variations.bravesoftware.com/seed \
 --variations-insecure-server-url=https://variations.bravesoftware.com/seed --fake-variations-channel=canary
 ```
 2. Ensure there is no `SyncResetProgressTokenStudy:Disabled` anymore at **Active Variations** section at brave://version/ page:
 
![Screenshot from 2023-05-09 14-07-44](https://github.com/brave/brave-variations/assets/24739341/89461571-7b2e-4b61-aa3d-b1834a069c95)

 