### PR TITLE
Enable BraveForgetFirstPartyStorage on Beta 100% desktop.

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1895,6 +1895,44 @@
                 {
                     "feature_association": {
                         "enable_feature": [
+                            "BraveForgetFirstPartyStorage"
+                        ]
+                    },
+                    "name": "Enabled",
+                    "probability_weight": 100
+                },
+                {
+                    "feature_association": {
+                        "disable_feature": [
+                            "BraveForgetFirstPartyStorage"
+                        ]
+                    },
+                    "name": "Disabled",
+                    "probability_weight": 0
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "channel": [
+                    "BETA"
+                ],
+                "min_version": "114.1.53.83",
+                "platform": [
+                    "WINDOWS",
+                    "MAC",
+                    "LINUX"
+                ]
+            },
+            "name": "BraveForgetFirstPartyStorage"
+        },
+        {
+            "experiments": [
+                {
+                    "feature_association": {
+                        "enable_feature": [
                             "Speedreader"
                         ]
                     },


### PR DESCRIPTION
Enable BraveForgetFirstPartyStorage in beta builds (~~25%~~ 100%).

100% as requested here https://bravesoftware.slack.com/archives/C01LKMP6X36/p1686593307877159?thread_ts=1686590960.525219&cid=C01LKMP6X36

This will add a new option to the Shields popup.
https://github.com/brave/brave-core/pull/18014#issuecomment-1505326910