### PR TITLE
Rollout SERP attribution to nightly @ 25%

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2121,6 +2121,38 @@
                 ]
             },
             "name": "BraveLocalhostAccessPermissionStudy"
+        },
+        {
+            "experiments": [
+                {
+                    "feature_association": {
+                        "enable_feature": [
+                            "ShouldLaunchBraveAdsAsInProcessService",
+                            "ShouldAlwaysRunBraveAdsService",
+                            "ShouldSupportSearchResultAds",
+                            "ShouldAlwaysTriggerBraveSearchResultAdEvents"
+                        ]
+                    },
+                    "name": "Enabled",
+                    "probability_weight": 25
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 75
+                }
+            ],
+            "filter": {
+                "channel": [
+                    "NIGHTLY"
+                ],
+                "platform": [
+                    "WINDOWS",
+                    "MAC",
+                    "LINUX",
+                    "ANDROID"
+                ]
+            },
+            "name": "BraveSearchAdStudy"
         }
     ],
     "version": "1"


### PR DESCRIPTION
Enables the following features on nightly for 25% of users:

`ShouldLaunchBraveAdsAsInProcessService`
`ShouldAlwaysRunBraveAdsService`
`ShouldSupportSearchResultAds`
