### PR TITLE
Rollout custom notification ads to 100% for Nightly (Windows, Mac).

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2257,6 +2257,88 @@
                 ]
             },
             "name": "BraveAIChatEnabledStudy"
+        },
+        {
+            "experiments": [
+                {
+                    "feature_association": {
+                        "enable_feature": [
+                            "CustomNotificationAds"
+                        ]
+                    },
+                    "name": "normalized_display_coordinate_x/1/normalized_display_coordinate_y/0/inset_x/0/inset_y/220",
+                    "parameters": [
+                        {
+                            "name": "normalized_display_coordinate_x",
+                            "value": "1"
+                        },
+                        {
+                            "name": "normalized_display_coordinate_y",
+                            "value": "0"
+                        },
+                        {
+                            "name": "inset_x",
+                            "value": "0"
+                        },
+                        {
+                            "name": "inset_y",
+                            "value": "220"
+                        }
+                    ],
+                    "probability_weight": 100
+                }
+            ],
+            "filter": {
+                "channel": [
+                    "NIGHTLY"
+                ],
+                "min_version": "115.1.58.35",
+                "platform": [
+                    "MAC"
+                ]
+            },
+            "name": "BraveAds.CustomNotificationAdsMacStudy"
+        },
+        {
+            "experiments": [
+                {
+                    "feature_association": {
+                        "enable_feature": [
+                            "CustomNotificationAds"
+                        ]
+                    },
+                    "name": "normalized_display_coordinate_x/1/normalized_display_coordinate_y/0/inset_x/0/inset_y/72",
+                    "parameters": [
+                        {
+                            "name": "normalized_display_coordinate_x",
+                            "value": "1"
+                        },
+                        {
+                            "name": "normalized_display_coordinate_y",
+                            "value": "0"
+                        },
+                        {
+                            "name": "inset_x",
+                            "value": "0"
+                        },
+                        {
+                            "name": "inset_y",
+                            "value": "72"
+                        }
+                    ],
+                    "probability_weight": 100
+                }
+            ],
+            "filter": {
+                "channel": [
+                    "NIGHTLY"
+                ],
+                "min_version": "115.1.58.35",
+                "platform": [
+                    "WINDOWS"
+                ]
+            },
+            "name": "BraveAds.CustomNotificationAdsWindowsStudy"
         }
     ],
     "version": "1"


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-variations/pull/697

Rollout `CustomNotificationAds` to 100% for Nightly on Windows and Mac platforms with parameters:

* Windows: `normalized_display_coordinate_x/1/normalized_display_coordinate_y/0/inset_x/0/inset_y/72` 
* Mac: `normalized_display_coordinate_x/1/normalized_display_coordinate_y/0/inset_x/0/inset_y/220` 

`use_same_z_order_as_browser_window` parameter value is set to `true` by default in the source code, so the custom notification ad is using the same z-order as the browser window.

# Test plan

* Start with the fresh profile
* Join Brave rewards
* Trigger a custom notification ad
* Make sure that the custom notification ad appears at the top right corner with:
  - 72 px inset from the top on Windows
  - 220 px inset from the top on MacOS