### PR TITLE
Rollout SERP attribution phase 3 to release channel @ 50%

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2340,11 +2340,11 @@
                         ]
                     },
                     "name": "Enabled",
-                    "probability_weight": 25
+                    "probability_weight": 50
                 },
                 {
                     "name": "Default",
-                    "probability_weight": 75
+                    "probability_weight": 50
                 }
             ],
             "filter": {


### PR DESCRIPTION
This feature has been on beta/nightly at 100% for quite a while. And we have previously rolled out to 25% on desktop and Android. This PR is asking to rollout to 50% of release channel users.