### PR TITLE
Roll out horizontal tabs update to Beta

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2537,7 +2537,8 @@
             ],
             "filter": {
                 "channel": [
-                    "NIGHTLY"
+                    "NIGHTLY",
+                    "BETA"
                 ],
                 "platform": [
                     "WINDOWS",


### PR DESCRIPTION
Rolls out `#brave-horizontal-tabs-update` to Beta at 100%.

* Feature: https://github.com/brave/brave-browser/issues/31646
* Flag: `brave://flags/#brave-horizontal-tabs-update`