### PR TITLE
Support iOS in finch tracker & griffin.brave.com

### DIFF
--- a/src/core/base_types.ts
+++ b/src/core/base_types.ts
@@ -14,4 +14,7 @@ export class ProcessingOptions {
   // taken from API.
   // Studies that target to older versions are considered as outdated.
   minMajorVersion: number;
+
+  // True if study is originated from Brave (Griffin), false for upstream.
+  isBraveSeed: boolean;
 }

--- a/src/finch_tracker/main.ts
+++ b/src/finch_tracker/main.ts
@@ -69,6 +69,7 @@ async function main(): Promise<void> {
 
   const options: ProcessingOptions = {
     minMajorVersion,
+    isBraveSeed: false,
   };
 
   const outputFile = program.opts().output;

--- a/src/finch_tracker/tracker_lib.test.ts
+++ b/src/finch_tracker/tracker_lib.test.ts
@@ -23,7 +23,10 @@ function serialize(json: Record<string, any>) {
 
 test('seed serialization', () => {
   const data = fs.readFileSync('test/data/seed1.bin');
-  const map = serializeStudies(data, { minMajorVersion: 116 });
+  const map = serializeStudies(data, {
+    minMajorVersion: 116,
+    isBraveSeed: true,
+  });
   const serializedOutput = serialize(map);
 
   const serializedExpectations = fs
@@ -87,7 +90,7 @@ describe('summary', () => {
   const summary = makeSummary(
     oldSeed,
     newSeed,
-    { minMajorVersion: 116 },
+    { minMajorVersion: 116, isBraveSeed: true },
     StudyPriority.STABLE_MIN,
   );
 

--- a/src/web/app/seed_loader.ts
+++ b/src/web/app/seed_loader.ts
@@ -48,13 +48,14 @@ async function loadSeedFromUrl(url: string, type: SeedType) {
   const data = await loadFile(url, 'arraybuffer');
   const seedBytes = new Uint8Array(data);
   const seed = proto.VariationsSeed.decode(seedBytes);
-  const isBrave = type !== SeedType.UPSTREAM;
+  const isBraveSeed = type !== SeedType.UPSTREAM;
 
   // Desktop/Android could use a different major chrome version.
   // Use -1 version for Brave studies to make sure that we don't cut
   // anything important.
-  const minMajorVersion = (await getCurrentMajorVersion) - (isBrave ? 1 : 0);
-  const options: ProcessingOptions = { minMajorVersion };
+  const minMajorVersion =
+    (await getCurrentMajorVersion) - (isBraveSeed ? 1 : 0);
+  const options: ProcessingOptions = { minMajorVersion, isBraveSeed };
   const studies: StudyModel[] = [];
   seed.study.forEach((study, index) => {
     const processed = new ProcessedStudy(study, options);

--- a/src/web/app/study_model.test.ts
+++ b/src/web/app/study_model.test.ts
@@ -15,7 +15,10 @@ import { SeedType } from '../../core/base_types';
 
 function makeStudyModel(properties: proto.IStudy) {
   const study = new proto.Study(properties);
-  const processed = new ProcessedStudy(study, { minMajorVersion: 116 });
+  const processed = new ProcessedStudy(study, {
+    minMajorVersion: 116,
+    isBraveSeed: true,
+  });
   const randomID = Math.floor(Math.random() * 1000000);
   return new StudyModel(processed, SeedType.PRODUCTION, randomID);
 }
@@ -43,7 +46,10 @@ describe('models', () => {
     ],
     filter: {
       channel: [proto.Study.Channel.STABLE, proto.Study.Channel.CANARY],
-      platform: [proto.Study.Platform.PLATFORM_WINDOWS],
+      platform: [
+        proto.Study.Platform.PLATFORM_WINDOWS,
+        proto.Study.Platform.PLATFORM_IOS,
+      ],
     },
   });
 
@@ -82,7 +88,7 @@ describe('models', () => {
     expect(studyList.filterStudies(filter).length).toBe(1);
 
     expect(study1.channels()).toStrictEqual(['NIGHTLY', 'RELEASE']);
-    expect(study1.platforms()).toStrictEqual(['WINDOWS']);
+    expect(study1.platforms()).toStrictEqual(['WINDOWS', 'IOS']);
     const experiments = study1.filterExperiments(filter);
     expect(experiments.length).toBe(2);
     expect(experiments[0].name()).toBe('Enabled');


### PR DESCRIPTION
For https://github.com/brave/brave-variations/issues/741
The PRs add iOS support for griffin.brave.com & finch-tracker.
1. `finch-data-private`, `#finch-updates` and `UPSTREAM` tab in griffin.brave.com continue to ignore iOS. We are not interested in upstream experiments because brave-ios isn't Chromium-based.
2. `PRODUCTION` and `UPSTREAM` tabs start to show iOS studies.