### PR TITLE
Enable Playlist feature for Desktop Nightly[Prod]

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2577,6 +2577,34 @@
                 ]
             },
             "name": "BraveHorizontalTabsUpdateEnabledStudy"
+        },
+        {
+            "experiments": [
+                {
+                    "feature_association": {
+                        "enable_feature": [
+                            "Playlist"
+                        ]
+                    },
+                    "name": "Enabled",
+                    "probability_weight": 100
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "channel": [
+                    "NIGHTLY"
+                ],
+                "platform": [
+                    "WINDOWS",
+                    "MAC",
+                    "LINUX"
+                ]
+            },
+            "name": "DefaultPlaylistStudy"
         }
     ],
     "version": "1"


### PR DESCRIPTION
resolves https://github.com/brave/brave-variations/issues/767

Now that the final security review was closed (https://github.com/brave/reviews/issues/1421), we can enable the playlist on Nightly.