### PR TITLE
Enabled WhatsNewStudy for 1.60 release

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2048,7 +2048,7 @@
                     "parameters": [
                         {
                             "name": "target_major_version_stable",
-                            "value": "1.52"
+                            "value": "1.60"
                         }
                     ],
                     "probability_weight": 100


### PR DESCRIPTION
Verified whats-new page is opened on 1.60.x release with staging (https://github.com/brave/brave-variations/pull/807).