### PR TITLE
Update for 1.60 which will show the Whats New page for folks

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2048,7 +2048,7 @@
                     "parameters": [
                         {
                             "name": "target_major_version_stable",
-                            "value": "1.52"
+                            "value": "1.60"
                         }
                     ],
                     "probability_weight": 100
@@ -2062,6 +2062,7 @@
                 "channel": [
                     "RELEASE"
                 ],
+                "min_version": "119.1.60.114",
                 "platform": [
                     "WINDOWS",
                     "MAC",


### PR DESCRIPTION
Will show for anyone who was on version 1.59 or earlier

Will not show for people whose first version of Brave was 1.60.110 (since 1.60.110 and 1.60.114 are the same MAJOR version)