### PR TITLE
Follow up to serp attribution phase 5 (#777)

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2310,7 +2310,49 @@
             "filter": {
                 "channel": [
                     "NIGHTLY",
-                    "BETA",
+                    "BETA"
+                ],
+                "platform": [
+                    "WINDOWS",
+                    "MAC",
+                    "LINUX",
+                    "ANDROID"
+                ]
+            },
+            "name": "BraveSearchAdStudy"
+        },
+        {
+            "experiments": [
+                {
+                    "feature_association": {
+                        "enable_feature": [
+                            "ShouldAlwaysRunBraveAdsService",
+                            "ShouldSupportSearchResultAds",
+                            "ShouldAlwaysTriggerBraveSearchResultAdEvents"
+                        ]
+                    },
+                    "name": "EnabledInUtility",
+                    "probability_weight": 90
+                },
+                {
+                    "feature_association": {
+                        "enable_feature": [
+                            "ShouldLaunchBraveAdsAsInProcessService",
+                            "ShouldAlwaysRunBraveAdsService",
+                            "ShouldSupportSearchResultAds",
+                            "ShouldAlwaysTriggerBraveSearchResultAdEvents"
+                        ]
+                    },
+                    "name": "EnabledInProcess",
+                    "probability_weight": 10
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "channel": [
                     "RELEASE"
                 ],
                 "platform": [


### PR DESCRIPTION
Fixes an issue with duplicate `enabled` for both experiments and updates the staging/production experiments to match.