### PR TITLE
Enable rounded webview corners in desktop Nightly and Beta (production)

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2557,6 +2557,31 @@
             "experiments": [
                 {
                     "feature_association": {
+                        "enable_feature": [
+                            "brave-web-view-rounded-corners"
+                        ]
+                    },
+                    "name": "Enabled",
+                    "probability_weight": 100
+                }
+            ],
+            "filter": {
+                "channel": [
+                    "NIGHTLY",
+                    "BETA"
+                ],
+                "platform": [
+                    "WINDOWS",
+                    "MAC",
+                    "LINUX"
+                ]
+            },
+            "name": "BraveWebViewRoundedCornersStudy"
+        },
+        {
+            "experiments": [
+                {
+                    "feature_association": {
                         "disable_feature": [
                             "SmilAutoSuspendOnLag"
                         ]


### PR DESCRIPTION
Enables https://github.com/brave/brave-browser/issues/31645 on Beta and Nightly.

Feature flag: `#brave-web-view-rounded-corners`