### PR TITLE
max_version for BraveAIChatEnabledStudy

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2463,6 +2463,7 @@
                 "channel": [
                     "RELEASE"
                 ],
+                "max_version": "119.1.60.119",
                 "min_version": "119.1.60.0",
                 "platform": [
                     "WINDOWS",


### PR DESCRIPTION
`BraveAIChatEnabledStudy` is at 100% and is enabled by default in brave-core via https://github.com/brave/brave-core/pull/20982, so set a `max_version` where that has landed