### PR TITLE
Android DefaultPassthroughCommandDecoder study with a block list by models

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2606,6 +2606,49 @@
                 ]
             },
             "name": "SmilAutoSuspendOnLagKillSwitch"
+        },
+        {
+            "experiments": [
+                {
+                    "feature_association": {
+                        "enable_feature": [
+                            "DefaultPassthroughCommandDecoder"
+                        ]
+                    },
+                    "name": "Enabled",
+                    "parameters": [
+                        {
+                            "name": "BlockListByModel",
+                            "value": "5030D_EEA|ASUS_Z008D|ASUS_Z00AD|CPH2*|Galaxy Tab 2 3G|GT-I9500|Infinix X6*|K016|K01Q|Lenovo TB-X*|LM-*|M2006C3*|moto e*|moto g*|MRD-LX1|Nokia 2.3|P01M*|P01T_1|RMX2185|SM-A*|Star 4|TBT8A10|TECNO K*|vivo*"
+                        }
+                    ],
+                    "probability_weight": 100
+                },
+                {
+                    "feature_association": {
+                        "disable_feature": [
+                            "DefaultPassthroughCommandDecoder"
+                        ]
+                    },
+                    "name": "Disabled",
+                    "probability_weight": 0
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "channel": [
+                    "NIGHTLY",
+                    "BETA",
+                    "RELEASE"
+                ],
+                "platform": [
+                    "ANDROID"
+                ]
+            },
+            "name": "DefaultPassthroughCommandDecoderStudy"
         }
     ],
     "version": "1"


### PR DESCRIPTION
A production version of https://github.com/brave/brave-variations/pull/838