### PR TITLE
Remove sorted keys requirement

### DIFF
--- a/.github/ci/griffin-study-utils.py
+++ b/.github/ci/griffin-study-utils.py
@@ -11,7 +11,7 @@ def _load_studies(filename="seed/seed.json"):
 
 def _save_studies(studies, filename="seed/seed.json"):
     with open(filename, "w") as fh:
-        json.dump(studies, fh, sort_keys=True, indent=4)
+        json.dump(studies, fh, indent=4)
 
 
 def _create_study(


### PR DESCRIPTION
Remove requirement to sort JSON keys. Chromium do not have this requirement, which causes a lot of pain when adding Finch kill switches.