### PR TITLE
[Brave News]: Enable FeedV2 in Release 1.62

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -75,6 +75,35 @@
                 {
                     "feature_association": {
                         "enable_feature": [
+                            "BraveNewsFeedUpdate"
+                        ]
+                    },
+                    "name": "Enabled",
+                    "probability_weight": 100
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "channel": [
+                    "RELEASE"
+                ],
+                "min_version": "120.0.6099.217",
+                "platform": [
+                    "WINDOWS",
+                    "MAC",
+                    "LINUX"
+                ]
+            },
+            "name": "DefaultBraveCommandsStudy"
+        },
+        {
+            "experiments": [
+                {
+                    "feature_association": {
+                        "enable_feature": [
                             "BraveGoogleSignInPermission"
                         ]
                     },


### PR DESCRIPTION
@kjozwiak I'd like to enable this just in 1.62.x but they're both on the same Chromium version, as best I can tell