### PR TITLE
Cleanup CustomNotificationAds study parameters

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2396,26 +2396,12 @@
                             "CustomNotificationAds"
                         ]
                     },
-                    "name": "normalized_display_coordinate_x=1|normalized_display_coordinate_y=0|inset_x=0|inset_y=220",
-                    "parameters": [
-                        {
-                            "name": "normalized_display_coordinate_x",
-                            "value": "1"
-                        },
-                        {
-                            "name": "normalized_display_coordinate_y",
-                            "value": "0"
-                        },
-                        {
-                            "name": "inset_x",
-                            "value": "0"
-                        },
-                        {
-                            "name": "inset_y",
-                            "value": "220"
-                        }
-                    ],
+                    "name": "Enabled",
                     "probability_weight": 100
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
                 }
             ],
             "filter": {
@@ -2425,52 +2411,11 @@
                 ],
                 "min_version": "115.1.58.35",
                 "platform": [
+                    "WINDOWS",
                     "MAC"
                 ]
             },
-            "name": "BraveAds.CustomNotificationAdsMacStudy"
-        },
-        {
-            "experiments": [
-                {
-                    "feature_association": {
-                        "enable_feature": [
-                            "CustomNotificationAds"
-                        ]
-                    },
-                    "name": "normalized_display_coordinate_x=1|normalized_display_coordinate_y=0|inset_x=0|inset_y=72",
-                    "parameters": [
-                        {
-                            "name": "normalized_display_coordinate_x",
-                            "value": "1"
-                        },
-                        {
-                            "name": "normalized_display_coordinate_y",
-                            "value": "0"
-                        },
-                        {
-                            "name": "inset_x",
-                            "value": "0"
-                        },
-                        {
-                            "name": "inset_y",
-                            "value": "72"
-                        }
-                    ],
-                    "probability_weight": 100
-                }
-            ],
-            "filter": {
-                "channel": [
-                    "NIGHTLY",
-                    "BETA"
-                ],
-                "min_version": "115.1.58.35",
-                "platform": [
-                    "WINDOWS"
-                ]
-            },
-            "name": "BraveAds.CustomNotificationAdsWindowsStudy"
+            "name": "BraveAds.CustomNotificationAdsStudy"
         },
         {
             "experiments": [


### PR DESCRIPTION
Custom notification ad griffin parameters are not needed, because they became obsolete and default ones are already used. 
Custom notification ad study is running for Nightly and Beta, so this change won't affect Release. These parameters were used to change position of first notification ad show only so it won't break notification ad for browsers with an old version.

