### PR TITLE
Roll in-process brave ads to 100% on Android

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2333,83 +2333,13 @@
             "filter": {
                 "channel": [
                     "NIGHTLY",
-                    "BETA"
+                    "BETA",
+                    "RELEASE"
                 ],
                 "platform": [
                     "WINDOWS",
                     "MAC",
                     "LINUX",
-                    "ANDROID"
-                ]
-            },
-            "name": "BraveSearchAdStudy"
-        },
-        {
-            "experiments": [
-                {
-                    "feature_association": {
-                        "enable_feature": [
-                            "ShouldLaunchBraveAdsAsInProcessService",
-                            "ShouldAlwaysRunBraveAdsService",
-                            "ShouldSupportSearchResultAds",
-                            "ShouldAlwaysTriggerBraveSearchResultAdEvents"
-                        ]
-                    },
-                    "name": "EnabledInProcessDesktop",
-                    "probability_weight": 100
-                },
-                {
-                    "name": "Default",
-                    "probability_weight": 0
-                }
-            ],
-            "filter": {
-                "channel": [
-                    "RELEASE"
-                ],
-                "platform": [
-                    "WINDOWS",
-                    "MAC",
-                    "LINUX"
-                ]
-            },
-            "name": "BraveSearchAdStudy"
-        },
-        {
-            "experiments": [
-                {
-                    "feature_association": {
-                        "enable_feature": [
-                            "ShouldAlwaysRunBraveAdsService",
-                            "ShouldSupportSearchResultAds",
-                            "ShouldAlwaysTriggerBraveSearchResultAdEvents"
-                        ]
-                    },
-                    "name": "EnabledInUtility",
-                    "probability_weight": 50
-                },
-                {
-                    "feature_association": {
-                        "enable_feature": [
-                            "ShouldLaunchBraveAdsAsInProcessService",
-                            "ShouldAlwaysRunBraveAdsService",
-                            "ShouldSupportSearchResultAds",
-                            "ShouldAlwaysTriggerBraveSearchResultAdEvents"
-                        ]
-                    },
-                    "name": "EnabledInProcess",
-                    "probability_weight": 50
-                },
-                {
-                    "name": "Default",
-                    "probability_weight": 0
-                }
-            ],
-            "filter": {
-                "channel": [
-                    "RELEASE"
-                ],
-                "platform": [
                     "ANDROID"
                 ]
             },


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-variations/pull/910

# Test plan:

This should be tests on Desktop and Android platforms

- Start with a fresh profile
- Check that `BraveSearchAdStudy` variation is active
- Check that Brave Ads are started