### PR TITLE
Revert "Brave Ads new tab takeover iOS study (#928)" - Production

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2333,40 +2333,6 @@
                     "ANDROID"
                 ]
             }
-        },
-        {
-            "experiments": [
-                {
-                    "feature_association": {
-                        "enable_feature": [
-                            "BraveNTPBrandedWallpaper"
-                        ]
-                    },
-                    "name": "Enabled",
-                    "parameters": [
-                        {
-                            "name": "initial_count_to_branded_wallpaper",
-                            "value": "1"
-                        },
-                        {
-                            "name": "count_to_branded_wallpaper",
-                            "value": "2"
-                        }
-                    ],
-                    "probability_weight": 100
-                }
-            ],
-            "filter": {
-                "channel": [
-                    "RELEASE",
-                    "BETA",
-                    "NIGHTLY"
-                ],
-                "platform": [
-                    "IOS"
-                ]
-            },
-            "name": "NewTabPageTakeoverPositionStudy"
         }
     ],
     "version": "1"


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-variations/compare/revert_new_tab_takeover_ios?expand=1