### PR TITLE
Enable partitioned cookies.

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1411,6 +1411,38 @@
                 {
                     "feature_association": {
                         "enable_feature": [
+                            "PartitionedCookies"
+                        ]
+                    },
+                    "name": "Enabled",
+                    "probability_weight": 100
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "channel": [
+                    "NIGHTLY",
+                    "BETA",
+                    "RELEASE"
+                ],
+                "min_version": "122.1.63.0",
+                "platform": [
+                    "WINDOWS",
+                    "MAC",
+                    "LINUX",
+                    "ANDROID"
+                ]
+            },
+            "name": "PartitionedCookies"
+        },
+        {
+            "experiments": [
+                {
+                    "feature_association": {
+                        "enable_feature": [
                             "Speedreader"
                         ]
                     },


### PR DESCRIPTION
The study is to enable `PartitionedCookies` feature by default to unblock Microsoft login issues we're currently experiencing.

Original issue: https://github.com/brave/brave-browser/issues/36450

Uplift to beta: https://github.com/brave/brave-core/pull/22393
Uplift to release is green: https://github.com/brave/brave-core/pull/22394