### PR TITLE
Updated BraveSearchPromotionBannerStudy (#946)

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -726,21 +726,6 @@
                             "BraveSearchOmniboxBanner"
                         ]
                     },
-                    "name": "banner_type_A",
-                    "parameters": [
-                        {
-                            "name": "banner_type",
-                            "value": "type_A"
-                        }
-                    ],
-                    "probability_weight": 25
-                },
-                {
-                    "feature_association": {
-                        "enable_feature": [
-                            "BraveSearchOmniboxBanner"
-                        ]
-                    },
                     "name": "banner_type_B",
                     "parameters": [
                         {
@@ -748,7 +733,7 @@
                             "value": "type_B"
                         }
                     ],
-                    "probability_weight": 25
+                    "probability_weight": 33
                 },
                 {
                     "feature_association": {
@@ -763,7 +748,7 @@
                             "value": "type_C"
                         }
                     ],
-                    "probability_weight": 25
+                    "probability_weight": 33
                 },
                 {
                     "feature_association": {
@@ -778,11 +763,12 @@
                             "value": "type_D"
                         }
                     ],
-                    "probability_weight": 25
+                    "probability_weight": 34
                 }
             ],
             "filter": {
                 "channel": [
+                    "BETA",
                     "NIGHTLY"
                 ],
                 "country": [


### PR DESCRIPTION
issue: https://github.com/brave/brave-browser/issues/36499

Removed type A banner from study.