### PR TITLE
Disable UnifiedPasswordManagerLocalPasswordsMigrationWarning feature

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1120,6 +1120,29 @@
             "experiments": [
                 {
                     "feature_association": {
+                        "disable_feature": [
+                            "UnifiedPasswordManagerLocalPasswordsMigrationWarning"
+                        ]
+                    },
+                    "name": "Disabled",
+                    "probability_weight": 100
+                }
+            ],
+            "filter": {
+                "channel": [
+                    "NIGHTLY",
+                    "BETA"
+                ],
+                "platform": [
+                    "ANDROID"
+                ]
+            },
+            "name": "UnifiedPasswordManagerLocalPasswordsMigrationWarningSampling"
+        },
+        {
+            "experiments": [
+                {
+                    "feature_association": {
                         "enable_feature": [
                             "BraveAdblockMobileNotificationsListDefault"
                         ]


### PR DESCRIPTION
to prevent password migration warning on Android Nightly and Beta

Fixes https://github.com/brave/brave-browser/issues/35378