### PR TITLE
Revert "Disable UnifiedPasswordManagerLocalPasswordsMigrationWarning feature"

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1120,29 +1120,6 @@
             "experiments": [
                 {
                     "feature_association": {
-                        "disable_feature": [
-                            "UnifiedPasswordManagerLocalPasswordsMigrationWarning"
-                        ]
-                    },
-                    "name": "Disabled",
-                    "probability_weight": 100
-                }
-            ],
-            "filter": {
-                "channel": [
-                    "NIGHTLY",
-                    "BETA"
-                ],
-                "platform": [
-                    "ANDROID"
-                ]
-            },
-            "name": "UnifiedPasswordManagerLocalPasswordsMigrationWarningSampling"
-        },
-        {
-            "experiments": [
-                {
-                    "feature_association": {
                         "enable_feature": [
                             "BraveAdblockMobileNotificationsListDefault"
                         ]


### PR DESCRIPTION
Reverts brave/brave-variations#948

feature will be disabled with OVERRIDE_FEATURE_DEFAULT_STATES at brave-core