### PR TITLE
Change Brave Ads site visit page land event and text classification page history size

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2546,6 +2546,44 @@
                 "max_version": "124.*"
             },
             "name": "RendererAllocatesImagesKillSwitch"
+        },
+        {
+            "experiments": [
+                {
+                    "feature_association": {
+                        "enable_feature": [
+                            "SiteVisitFeature"
+                        ]
+                    },
+                    "name": "Enabled",
+                    "parameters": [
+                        {
+                            "name": "page_land_after",
+                            "value": "5s"
+                        }
+                    ],
+                    "probability_weight": 100
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "channel": [
+                    "NIGHTLY",
+                    "BETA",
+                    "RELEASE"
+                ],
+                "platform": [
+                    "WINDOWS",
+                    "MAC",
+                    "LINUX",
+                    "ANDROID",
+                    "IOS"
+                ]
+            },
+            "name": "BraveAdsSiteVisitStudy"
         }
     ],
     "version": "1"

--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2584,6 +2584,44 @@
                 ]
             },
             "name": "BraveAdsSiteVisitStudy"
+        },
+        {
+            "experiments": [
+                {
+                    "feature_association": {
+                        "enable_feature": [
+                            "TextClassification"
+                        ]
+                    },
+                    "name": "Enabled",
+                    "parameters": [
+                        {
+                            "name": "page_probabilities_history_size",
+                            "value": "15"
+                        }
+                    ],
+                    "probability_weight": 100
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "channel": [
+                    "NIGHTLY",
+                    "BETA",
+                    "RELEASE"
+                ],
+                "platform": [
+                    "WINDOWS",
+                    "MAC",
+                    "LINUX",
+                    "ANDROID",
+                    "IOS"
+                ]
+            },
+            "name": "BraveAdsTextClassificationPageProbabilitiesStudy"
         }
     ],
     "version": "1"


### PR DESCRIPTION
Reduce site visit/page land from 10s to 5s and increase text classification probability page history size from 5 to 15.