### PR TITLE
Enable HistoryMoreSearchResults in Nightly

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -75,6 +75,34 @@
                 {
                     "feature_association": {
                         "enable_feature": [
+                            "HistoryMoreSearchResults"
+                        ]
+                    },
+                    "name": "Enabled",
+                    "probability_weight": 100
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "channel": [
+                    "NIGHTLY"
+                ],
+                "platform": [
+                    "WINDOWS",
+                    "MAC",
+                    "LINUX"
+                ]
+            },
+            "name": "DefaultBraveOmniboxMoreHistoryStudy"
+        },
+        {
+            "experiments": [
+                {
+                    "feature_association": {
+                        "enable_feature": [
                             "BraveNewsFeedUpdate"
                         ]
                     },


### PR DESCRIPTION
This flag lets more history search results show up in the omnibox