### PR TITLE
Change site visit page land cap to infinite

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2490,6 +2490,10 @@
                         {
                             "name": "page_land_after",
                             "value": "5s"
+                        },
+                        {
+                            "name": "page_land_cap",
+                            "value": "0"
                         }
                     ],
                     "probability_weight": 100


### PR DESCRIPTION
Disable site visit/page land frequency cap by changing the cap from 1 to 0 (infinite)