### PR TITLE
Add NewTabPageTriggerForPrerender2Killswitch

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2533,6 +2533,34 @@
                     "ANDROID"
                 ]
             }
+        },
+        {
+            "name": "NewTabPageTriggerForPrerender2Killswitch",
+            "experiments": [
+                {
+                    "name": "Disabled_NewTabPageTriggerForPrerender2",
+                    "probability_weight": 100,
+                    "feature_association": {
+                        "disable_feature": [
+                            "NewTabPageTriggerForPrerender2"
+                        ]
+                    }
+                }
+            ],
+            "filter": {
+                "min_version": "118.*",
+                "max_version": "125.*",
+                "channel": [
+                    "NIGHTLY",
+                    "BETA",
+                    "RELEASE"
+                ],
+                "platform": [
+                    "WINDOWS",
+                    "MAC",
+                    "LINUX"
+                ]
+            }
         }
     ],
     "version": "1"


### PR DESCRIPTION
Resolves https://github.com/brave/brave-variations/issues/986
PR to main: https://github.com/brave/brave-variations/pull/987

No steps to reproduce for Brave, but it's likely result to NTP hang in some cases.
