### PR TITLE
GoogleSignInPermission 50% => 100% on Release

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -174,7 +174,7 @@
                         ]
                     },
                     "name": "Enabled",
-                    "probability_weight": 50
+                    "probability_weight": 100
                 },
                 {
                     "feature_association": {
@@ -183,7 +183,7 @@
                         ]
                     },
                     "name": "Disabled",
-                    "probability_weight": 50
+                    "probability_weight": 0
                 },
                 {
                     "name": "Default",


### PR DESCRIPTION
This feature not being rolled out everywhere is causing a lot of confusion: https://community.brave.com/t/allow-google-sign-in-for-third-parties-bug/507398/9