### PR TITLE
Roll BraveSearchAdStudy for 100% on iOS in Release

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1879,7 +1879,8 @@
             "filter": {
                 "channel": [
                     "NIGHTLY",
-                    "BETA"
+                    "BETA",
+                    "RELEASE"
                 ],
                 "min_version": "122.1.65.32",
                 "platform": [


### PR DESCRIPTION
Resolves https://github.com/brave/brave-variations/issues/1012

This was already tested for Desktop and Android for a very long time.
