### PR TITLE
Sort studies by name and add basic study intersection check.

### DIFF
--- a/seed/serialize.py
+++ b/seed/serialize.py
@@ -138,8 +138,8 @@ def validate(seed):
             version_to_int_array(study.get('filter', {}).get('max_version')),
         ]
 
-    def is_set_intersect(a, b):
-        return a == b or a.intersection(b)
+    def is_filter_set_intersect(a, b):
+        return not a or not b or a.intersection(b)
 
     def is_version_range_intersect(range1, range2):
         return compare_versions(range1[1], range2[0]) >= 0 and compare_versions(range2[1], range1[0]) >= 0
@@ -156,9 +156,9 @@ def validate(seed):
                 study2_channel = get_study_channels(study2)
                 study2_version_range = get_study_version_range(study2)
                 # Check if the studies overlap in platform
-                if is_set_intersect(study1_platform, study2_platform):
+                if is_filter_set_intersect(study1_platform, study2_platform):
                     # Check if the studies overlap in channel
-                    if is_set_intersect(study1_channel, study2_channel):
+                    if is_filter_set_intersect(study1_channel, study2_channel):
                         # Check if the studies overlap in version
                         if is_version_range_intersect(study1_version_range, study2_version_range):
                             raise ValueError(f"Studies overlap:\n{json.dumps(study1, indent=2)}\n\n{json.dumps(study2, indent=2)}")


### PR DESCRIPTION
Sort studies by name before generating seed.

This is a required change to migrate to per-file study structure, because per-file structure implies study enumeration in alphabetical order (as files lay on the file system).

This change should be a no-op as long as we don't have studies intersection. This PR adds the required validation to ensure we do not have this kind of intersection, which means if the seed is validated, then it doesn't depend on the initial order of studies in `seed.json` and it's safe to reorder studies.

Related https://github.com/brave/brave-browser/issues/33654