### PR TITLE
Sync HangWatcher main with production

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -500,7 +500,7 @@
                 {
                     "feature_association": {
                         "enable_feature": [
-                            "HangWatcher"
+                            "EnableHangWatcher"
                         ]
                     },
                     "name": "HangWatcherEnableDumps",
@@ -548,7 +548,7 @@
                     "LINUX"
                 ]
             },
-            "name": "EnableHangWatcher"
+            "name": "HangWatcher"
         },
         {
             "experiments": [


### PR DESCRIPTION
Fixes a conflict `main` vs `production`. 
production is a correct one: https://github.com/brave/brave-variations/blob/production/seed/seed.json#L509