### PR TITLE
Enable back reset sync progress marker study

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2835,46 +2835,6 @@
                 {
                     "feature_association": {
                         "enable_feature": [
-                            "ResetProgressMarkerOnCommitFailures"
-                        ]
-                    },
-                    "name": "Enabled",
-                    "probability_weight": 0
-                },
-                {
-                    "feature_association": {
-                        "disable_feature": [
-                            "ResetProgressMarkerOnCommitFailures"
-                        ]
-                    },
-                    "name": "Disabled",
-                    "probability_weight": 100
-                },
-                {
-                    "name": "Default",
-                    "probability_weight": 0
-                }
-            ],
-            "filter": {
-                "channel": [
-                    "NIGHTLY",
-                    "BETA",
-                    "RELEASE"
-                ],
-                "platform": [
-                    "WINDOWS",
-                    "MAC",
-                    "LINUX",
-                    "ANDROID"
-                ]
-            },
-            "name": "SyncResetProgressTokenStudy"
-        },
-        {
-            "experiments": [
-                {
-                    "feature_association": {
-                        "enable_feature": [
                             "Conversions"
                         ]
                     },


### PR DESCRIPTION
With feature ResetProgressMarkerOnCommitFailures is enabled, then when client receives CONFLICT or TRANSIENT_ERROR response form server - it resets the progress marker, so the records for the given type are re-fetched. Sometimes this fixes the error, sometimes the error re-appears, but in any way server load increases.

This procedure recently was disabled with PRs
https://github.com/brave/brave-variations/pull/1032
https://github.com/brave/brave-variations/pull/1031

to check if this procedure was the reason of the massive 504 errors.

It turned out that the procedure wasn't the reason of the massive 504 errors.  But there are clients which begun got CONFLICT commit errors, https://github.com/brave/brave-browser/issues/35042#issuecomment-2099841187 .

So we need get the procedure back.