### PR TITLE
Revert "Disable Canvas2DHibernation via a kill switch"

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2642,34 +2642,6 @@
             }
         },
         {
-            "experiments": [
-                {
-                    "feature_association": {
-                        "disable_feature": [
-                            "Canvas2DHibernation"
-                        ]
-                    },
-                    "name": "Disabled_EmergencyKillSwitch",
-                    "probability_weight": 100
-                }
-            ],
-            "filter": {
-                "channel": [
-                    "NIGHTLY",
-                    "BETA",
-                    "RELEASE"
-                ],
-                "max_version": "124.*",
-                "platform": [
-                    "WINDOWS",
-                    "MAC",
-                    "LINUX",
-                    "ANDROID"
-                ]
-            },
-            "name": "Canvas2DHibernation"
-        },
-        {
             "name": "BraveAdblockExperimentalListDefaultStudy",
             "experiments": [
                 {


### PR DESCRIPTION
Reverts brave/brave-variations#1061

Should be reverted: because that configuration results in major issues for Chrome:
https://bravesoftware.slack.com/archives/C05S50MFHPE/p1716286479607499?thread_ts=1715861386.121639&cid=C05S50MFHPE