### PR TITLE
Canvas related kill switches

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2642,6 +2642,35 @@
             }
         },
         {
+            "experiments": [
+                {
+                    "feature_association": {
+                        "disable_feature": [
+                            "Canvas2DHibernation",
+                            "EvictionUnlocksResources"
+                        ]
+                    },
+                    "name": "Disabled_EmergencyKillSwitch",
+                    "probability_weight": 100
+                }
+            ],
+            "filter": {
+                "channel": [
+                    "NIGHTLY",
+                    "BETA",
+                    "RELEASE"
+                ],
+                "max_version": "125.*",
+                "platform": [
+                    "WINDOWS",
+                    "MAC",
+                    "LINUX",
+                    "ANDROID"
+                ]
+            },
+            "name": "CanvasKillSwitches"
+        },
+        {
             "name": "BraveAdblockExperimentalListDefaultStudy",
             "experiments": [
                 {


### PR DESCRIPTION
For https://github.com/brave/brave-variations/issues/1060
PR to production: https://github.com/brave/brave-variations/pull/1068

Both features [need to be disabled](https://bravesoftware.slack.com/archives/C05S50MFHPE/p1716286479607499?thread_ts=1715861386.121639&cid=C05S50MFHPE).

We use `max_version: 125.*` because cr126 got the fix in the code, so we don't need to cover it. 
`min_version` isn't set because Finch config disables:
1. `EvictionUnlocksResources` for [>= cr124](https://github.com/brave/finch-data-private/blob/61315aa8a98eecb3e3ccbb53f4fa32966e558ccc/study/all-by-name/DisableEvictionUnlocksResources#L16) 
 (for <= cr123 it's disabled [in the code](https://source.chromium.org/chromium/chromium/src/+/refs/tags/123.0.6312.134:components/viz/common/features.cc;l=335) )
2. `Canvas2DHibernation` for [all the revisions](https://github.com/brave/finch-data-private/blob/97c067db94f591537dd894c975cecaf0f9cb3d57/study/all-by-name/DisableCanvasHibernation#L16).

P.S. Chrome has 2 separate studies, but it looks less reliable.

Steps to reproduce: https://issues.chromium.org/u/0/issues/341105739