### PR TITLE
Add Github actions linter

### DIFF
--- a/.github/matchers/actionlint-matcher.json
+++ b/.github/matchers/actionlint-matcher.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "actionlint",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -25,4 +25,4 @@ jobs:
           npm run build
           cd ./src/web/public
           aws s3 sync . s3://brave-production-griffin-origin/ --delete --exclude '*' --include 'index.html' --include 'bundle/*'
-          aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID --paths "/*"
+          aws cloudfront create-invalidation --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" --paths "/*"

--- a/.github/workflows/upsert-study.yml
+++ b/.github/workflows/upsert-study.yml
@@ -65,7 +65,7 @@ jobs:
             branch_name=pr-"${1}"-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
             git switch "${1}"
             git switch -c "${branch_name}"
-            .github/ci/griffin-study-utils.py upsert_study ${{ inputs.name }} ${{ inputs.enable_feature }} ${{ inputs.probability_enabled }} ${{ inputs.channel }} ${{ inputs.platform }} ${{ inputs.min_version }}
+            .github/ci/griffin-study-utils.py upsert_study "${{ inputs.name }}" "${{ inputs.enable_feature }}" "${{ inputs.probability_enabled }}" "${{ inputs.channel }}" "${{ inputs.platform }}" "${{ inputs.min_version }}"
             git add seed/seed.json
             git commit -m "Upsert study ${{ inputs.name }}"
             git push -u origin "${branch_name}"
@@ -88,8 +88,8 @@ jobs:
 
           gh pr edit "${pr_main_number}" -b "\`production\`: #${pr_production_number}"
           gh pr edit "${pr_production_number}" -b "\`main\`: #${pr_main_number}"
-          echo "pr_main_number=${pr_main_number}" >> $GITHUB_OUTPUT
-          echo "pr_production_number=${pr_production_number}" >> $GITHUB_OUTPUT
+          echo "pr_main_number=${pr_main_number}" >> "$GITHUB_OUTPUT"
+          echo "pr_production_number=${pr_production_number}" >> "$GITHUB_OUTPUT"
 
       - name: Report to slack
         id: slack

--- a/.github/workflows/validate-actions.yml
+++ b/.github/workflows/validate-actions.yml
@@ -1,0 +1,20 @@
+name: Lint GitHub Actions
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+
+      - name: Check workflow files
+        run: |
+          echo "::add-matcher::.github/matchers/actionlint-matcher.json"
+          docker run --rm -v "$PWD:/repo:ro" --workdir /repo rhysd/actionlint:1.7.1 -color
+        shell: bash


### PR DESCRIPTION
Add actions linter, because github does not notify if an action is broken, so it's possible to merge invalid action without noticing.