### PR TITLE
Add Griffin study for BraveWalletAnkrBalances feature

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2979,6 +2979,38 @@
                 ]
             },
             "name": "BraveAdsAdEventStudy"
+        },
+        {
+            "experiments": [
+                {
+                    "feature_association": {
+                        "enable_feature": [
+                            "BraveWalletAnkrBalances"
+                        ]
+                    },
+                    "name": "Enabled",
+                    "probability_weight": 50
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 50
+                }
+            ],
+            "filter": {
+                "channel": [
+                    "NIGHTLY",
+                    "BETA",
+                    "RELEASE"
+                ],
+                "platform": [
+                    "WINDOWS",
+                    "MAC",
+                    "LINUX",
+                    "ANDROID"
+                ],
+                "min_version": "120.*"
+            },
+            "name": "BraveWalletAnkrBalancesEnabled"
         }
     ],
     "version": "1"


### PR DESCRIPTION
Adding a study for the `BraveWalletAnkrBalances` feature enabling it for 50% of the users. The flag is available as of **1.62.x** and is disabled by default.