### PR TITLE
Remove Android from Ankr study

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2977,8 +2977,7 @@
                 "platform": [
                     "WINDOWS",
                     "MAC",
-                    "LINUX",
-                    "ANDROID"
+                    "LINUX"
                 ],
                 "min_version": "120.*"
             },


### PR DESCRIPTION
A study for `BraveWalletAnkrBalances` was added in https://github.com/brave/brave-variations/pull/1088, which included Android as one of the target platforms. However, due to some [issues](https://github.com/brave/brave-variations/pull/1088#issuecomment-2176599096) encountered in Android during QA, we are going ahead with the rollout of the study without Android.

This should continue to the be case until the Android issue has been resolved.