### PR TITLE
Deprecate all JSON P3A measurements for non-macOS/iOS platforms

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2929,6 +2929,36 @@
                 ]
             },
             "name": "BraveP3ANebulaNightlyBeta"
+        },
+        {
+            "experiments": [
+                {
+                    "feature_association": {
+                        "enable_feature": [
+                            "BraveP3AOtherJSONDeprecation"
+                        ]
+                    },
+                    "name": "Enabled",
+                    "probability_weight": 100
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "channel": [
+                    "NIGHTLY",
+                    "BETA",
+                    "RELEASE"
+                ],
+                "platform": [
+                    "WINDOWS",
+                    "LINUX",
+                    "ANDROID"
+                ]
+            },
+            "name": "BraveP3AJSONOtherDeprecation"
         }
     ],
     "version": "1"


### PR DESCRIPTION
To validate:

- Ensure no requests are sent to `p3a-json.brave.com` for non-macOS/iOS platforms
- Ensure requests are still sent to `p3a-json.brave.com` for macOS and iOS
- Ensure requests are sent to `star-randsrv.bsg.brave.com`, `collector.bsg.brave.com/typical`, `collector.bsg.brave.com/express`, `collector.bsg.brave.com/slow` and `collector.bsg.brave.com/creative` for all platforms