### PR TITLE
Updating most performant test leg of ad model predictor recency study

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2351,28 +2351,7 @@
                             "value": "0.0"
                         }
                     ],
-                    "probability_weight": 20
-                },
-                {
-                    "feature_association": {
-                        "enable_feature": [
-                            "CreativeNotificationAdModelBasedPredictor",
-                            "CreativeNewTabPageAdModelBasedPredictor",
-                            "CreativeInlineContentAdModelBasedPredictor"
-                        ]
-                    },
-                    "name": "NoAdvertiserRecency",
-                    "parameters": [
-                        {
-                            "name": "last_seen_advertiser_predictor_weight",
-                            "value": "0.0"
-                        }
-                    ],
-                    "probability_weight": 20
-                },
-                {
-                    "name": "Control",
-                    "probability_weight": 60
+                    "probability_weight": 100
                 }
             ],
             "filter": {
@@ -2381,6 +2360,7 @@
                     "BETA",
                     "RELEASE"
                 ],
+                "max_version": "128.1.69.51",
                 "platform": [
                     "WINDOWS",
                     "MAC",


### PR DESCRIPTION
Updating most performant test leg of ad model predictor recency study to 100% until brave-core changes reach production.

Issue: https://github.com/brave/brave-variations/issues/1114
Changes become permanent in brave-core via this PR: https://github.com/brave/brave-core/pull/24253