### PR TITLE
Add postinstall script to generate protobuf js/ts files.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "brave-variations",
       "version": "0.0.1",
+      "hasInstallScript": true,
       "license": "MPL-2.0",
       "dependencies": {
         "@protobuf-ts/runtime": "2.9.4",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build:web": "webpack -c src/web/webpack.config.js --mode=production",
     "clean": "tsx src/scripts/clean.ts",
     "lint": "tsx src/scripts/lint.ts",
+    "postinstall": "npm run typecheck:scripts && npm run build:proto",
     "seed_tools": "tsx src/seed_tools/seed_tools.ts",
     "serve:dev": "webpack serve -c src/web/webpack.config.js --hot --mode=development",
     "test": "jest --config=src/jest.config.js",


### PR DESCRIPTION
We don't commit generated js/ts files, but they are required for `lint` command. This command will be used by users most of the time.