### PR TITLE
Test rebuild trigger

### DIFF
--- a/.github/workflows/generate-test-seed.yml
+++ b/.github/workflows/generate-test-seed.yml
@@ -2,6 +2,7 @@ name: Generate Test Seed
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - 'seed/seed.json'
       - 'studies/**'
@@ -9,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.event.action != 'labeled' || github.event.label.name == 'CI/rebuild'
+
     env:
       ACTION_RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
       BASE_SHA: '${{ github.event.pull_request.base.sha }}'
@@ -17,10 +20,22 @@ jobs:
       SEED_VERSION: 'pull/${{ github.event.pull_request.number }}@${{ github.sha }}'
 
     steps:
+      - name: Remove CI/rebuild label
+        if: github.event.action == 'labeled' && github.event.label.name == 'CI/rebuild'
+        run: gh pr edit ${{ github.event.pull_request.number }} --remove-label 'CI/rebuild'
+
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 
       - name: Fetch base commit
         run: git fetch --depth=1 origin "$BASE_SHA"
+
+      - name: Rebase on base branch
+        run: |
+          echo "${{ contains(github.event.pull_request.labels.*.name, 'CI/no-rebase') }}"
+          if [[ -z "${{ github.event.pull_request.labels }}" ]] || [[ -z "$(echo "${{ github.event.pull_request.labels }}" | grep 'CI/no-rebase')" ]]; then
+            git fetch origin "${{ github.event.pull_request.base.sha }}"
+            git rebase FETCH_HEAD
+          fi
 
       - name: Setup Python
         uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5

--- a/.github/workflows/test-src.yml
+++ b/.github/workflows/test-src.yml
@@ -2,15 +2,21 @@ name: Tracker&Griffin tests
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
   merge_group:
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.event.action != 'labeled' || github.event.label.name == 'CI/rebuild'
     env:
       BASE_SHA: '${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}'
 
     steps:
+      - name: Remove CI/rebuild label
+        if: github.event.action == 'labeled' && github.event.label.name == 'CI/rebuild'
+        run: gh pr edit ${{ github.event.pull_request.number }} --remove-label 'CI/rebuild'
+
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 
       - name: fetch base commit

--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2958,5 +2958,5 @@
             "name": "NewiOSPlaylistUIStudy"
         }
     ],
-    "version": "1"
+    "version": "2"
 }


### PR DESCRIPTION
TODO for a rebuild trigger via label to work:

1. add a separate workflow that will act on label add.
2. this separate workflow should trigger all required jobs via `workflow_dispatch`.

I haven't found a way to simulate "pull_request" event to trigger related jobs as if Github triggered them in a normal way.

the workflow that builds/tests stuff cannot act on label add on its own, because **any** added label will invalidate the last job state.