### PR TITLE
Disabled DefaultPassthroughCommandDecoder flag on Android to follow upstream

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2158,27 +2158,12 @@
             "experiments": [
                 {
                     "feature_association": {
-                        "enable_feature": [
-                            "DefaultPassthroughCommandDecoder"
-                        ]
-                    },
-                    "name": "Enabled",
-                    "parameters": [
-                        {
-                            "name": "BlockListByModel",
-                            "value": "5030D_EEA|ASUS_Z008D|ASUS_Z00AD|CPH2*|Galaxy Tab 2 3G|GT-I9500|Infinix X6*|K016|K01Q|Lenovo TB-X*|LM-*|M2006C3*|moto e*|moto g*|MRD-LX1|Nokia 2.3|P01M*|P01T_1|RMX2185|SM-A*|Star 4|TBT8A10|TECNO K*|vivo*"
-                        }
-                    ],
-                    "probability_weight": 100
-                },
-                {
-                    "feature_association": {
                         "disable_feature": [
                             "DefaultPassthroughCommandDecoder"
                         ]
                     },
                     "name": "Disabled",
-                    "probability_weight": 0
+                    "probability_weight": 100
                 },
                 {
                     "name": "Default",
@@ -2191,6 +2176,7 @@
                     "BETA",
                     "RELEASE"
                 ],
+                "min_version": "125.*",
                 "platform": [
                     "ANDROID"
                 ]


### PR DESCRIPTION
Resolves https://github.com/brave/brave-variations/issues/1153
Resolves https://github.com/brave/brave-browser/issues/40225

I don't think anyone has a problem device except me currently. I can confirm that I don't see the problem once I disable the flag and that's how it is in Chrome as well. There are also reports from users that disabling it fixes the issue 
https://community.brave.com/t/youtube-all-videos-appear-as-a-pink-screen-since-brave-version-1-68-128/560453/1
https://www.reddit.com/r/brave_browser/comments/1eeaz1j/youtube_pink_video_issue/
It could be verified that passthrough feature is disabled from chrome://gpu. Make sure you have `Passthrough Command Decoder` set to false in `Driver Information` section there after the variation applies. That flag is enabled by default, we want to disable it.
![Screenshot_20240802-091924](https://github.com/user-attachments/assets/72e3ce78-53d8-4563-b589-65ce5996b361)
