### PR TITLE
Add new `UndecryptablePasswords` study

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -3037,6 +3037,37 @@
                 ]
             },
             "name": "NewiOSPlaylistUIStudy"
+        },
+        {
+            "experiments": [
+                {
+                    "feature_association": {
+                        "enable_feature": [
+                            "SkipUndecryptablePasswords"
+                        ]
+                    },
+                    "name": "Enabled",
+                    "probability_weight": 100
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "min_version": "127.1.68.107",
+                "channel": [
+                    "NIGHTLY",
+                    "BETA",
+                    "RELEASE"
+                ],
+                "platform": [
+                    "WINDOWS",
+                    "MAC",
+                    "LINUX"
+                ]
+            },
+            "name": "UndecryptablePasswords"
         }
     ],
     "version": "1"


### PR DESCRIPTION
Enables the `SkipUndecryptablePasswords` feature to help users who are not able to see their logins in brave://password-manager/passwords

Fixes https://github.com/brave/brave-variations/issues/1164

Main issue tracked with https://github.com/brave/brave-browser/issues/33548