### PR TITLE
Use main branch only when upserting a study.

### DIFF
--- a/.github/workflows/upsert-study.yml
+++ b/.github/workflows/upsert-study.yml
@@ -82,14 +82,7 @@ jobs:
           get_pr_number
           pr_main_number=${pr_number:?}
 
-          upsert_study production
-          get_pr_number
-          pr_production_number=${pr_number:?}
-
-          gh pr edit "${pr_main_number}" -b "\`production\`: #${pr_production_number}"
-          gh pr edit "${pr_production_number}" -b "\`main\`: #${pr_main_number}"
           echo "pr_main_number=${pr_main_number}" >> "$GITHUB_OUTPUT"
-          echo "pr_production_number=${pr_production_number}" >> "$GITHUB_OUTPUT"
 
       - name: Report to slack
         id: slack
@@ -98,13 +91,13 @@ jobs:
           channel-id: 'C01LKMP6X36'
           payload: |
             {
-              "text": "${{ github.actor }} is requesting that we set the `${{ inputs.enable_feature }}` feature on channels `${{ inputs.channel }}` to `${{ inputs.probability_enabled }}%` on platforms `${{ inputs.platform }}` via the `${{ inputs.name }}` Griffin study using the following PR(s):\n- main <https://github.com/brave/brave-variations/pull/${{ steps.upsert.outputs.pr_main_number }}|${{ steps.upsert.outputs.pr_main_number }}>\n- production <https://github.com/brave/brave-variations/pull/${{ steps.upsert.outputs.pr_production_number }}|${{ steps.upsert.outputs.pr_production_number }}>",
+              "text": "${{ github.actor }} is requesting that we set the `${{ inputs.enable_feature }}` feature on channels `${{ inputs.channel }}` to `${{ inputs.probability_enabled }}%` on platforms `${{ inputs.platform }}` via the `${{ inputs.name }}` Griffin study using the following PR: <https://github.com/brave/brave-variations/pull/${{ steps.upsert.outputs.pr_main_number }}|${{ steps.upsert.outputs.pr_main_number }}>.",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "${{ github.actor }} is requesting that we set the `${{ inputs.enable_feature }}` feature on channels `${{ inputs.channel }}` to `${{ inputs.probability_enabled }}%` on platforms `${{ inputs.platform }}` via the `${{ inputs.name }}` Griffin study using the following PR(s):\n- main <https://github.com/brave/brave-variations/pull/${{ steps.upsert.outputs.pr_main_number }}|${{ steps.upsert.outputs.pr_main_number }}>\n- production <https://github.com/brave/brave-variations/pull/${{ steps.upsert.outputs.pr_production_number }}|${{ steps.upsert.outputs.pr_production_number }}>"
+                    "text": "${{ github.actor }} is requesting that we set the `${{ inputs.enable_feature }}` feature on channels `${{ inputs.channel }}` to `${{ inputs.probability_enabled }}%` on platforms `${{ inputs.platform }}` via the `${{ inputs.name }}` Griffin study using the following PR: <https://github.com/brave/brave-variations/pull/${{ steps.upsert.outputs.pr_main_number }}|${{ steps.upsert.outputs.pr_main_number }}>."
                   }
                 }
               ]


### PR DESCRIPTION
Remove `production` mentions from the upsert workflow.