### PR TITLE
Removes SpeedreaderAndroidStudy to have Speedreader in default state

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1406,34 +1406,6 @@
         {
             "experiments": [
                 {
-                    "feature_association": {
-                        "enable_feature": [
-                            "Speedreader"
-                        ]
-                    },
-                    "name": "Enabled",
-                    "probability_weight": 100
-                },
-                {
-                    "name": "Default",
-                    "probability_weight": 0
-                }
-            ],
-            "filter": {
-                "channel": [
-                    "NIGHTLY",
-                    "BETA"
-                ],
-                "min_version": "111.1.50.107",
-                "platform": [
-                    "ANDROID"
-                ]
-            },
-            "name": "SpeedreaderAndroidStudy"
-        },
-        {
-            "experiments": [
-                {
                     "name": "Enabled",
                     "parameters": [
                         {


### PR DESCRIPTION
Resolves https://github.com/brave/brave-variations/issues/1174

Test plan:
- make sure that there is no `SpeedreaderAndroidStudy`