### PR TITLE
Removes VulkanStudy on Android

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -248,57 +248,6 @@
                 {
                     "feature_association": {
                         "enable_feature": [
-                            "Vulkan"
-                        ]
-                    },
-                    "name": "Enabled",
-                    "parameters": [
-                        {
-                            "name": "BlockListByBoard",
-                            "value": "RM67*|RM68*|k68*|mt6*|oppo67*|oppo68*|QM215|rk30sdk|secret|maltose|rosemary|HLTE322E*|lisbon|lancelot|Infinix-X695|g2062upt_v1_gd_sh2_gq_eea_r|cannong|TECNO-CG8"
-                        },
-                        {
-                            "name": "disable_by_gl_renderer",
-                            "value": "*Mali-G72*|*Mali-G?? M*"
-                        },
-                        {
-                            "name": "enable_by_device_name",
-                            "value": "Adreno*630"
-                        }
-                    ],
-                    "probability_weight": 100
-                },
-                {
-                    "feature_association": {
-                        "disable_feature": [
-                            "Vulkan"
-                        ]
-                    },
-                    "name": "Disabled",
-                    "probability_weight": 0
-                },
-                {
-                    "name": "Default",
-                    "probability_weight": 0
-                }
-            ],
-            "filter": {
-                "channel": [
-                    "NIGHTLY",
-                    "BETA",
-                    "RELEASE"
-                ],
-                "platform": [
-                    "ANDROID"
-                ]
-            },
-            "name": "VulkanStudy"
-        },
-        {
-            "experiments": [
-                {
-                    "feature_association": {
-                        "enable_feature": [
                             "EphemeralStorage"
                         ]
                     },


### PR DESCRIPTION
Resolves https://github.com/brave/brave-variations/issues/1188
I was able to replicate a blank page on one of Motorola devices, where it falls under blocklist. Force enabling it shows the page and I haven't seen any issues with YouTube videos.