### PR TITLE
Enable BraveWorkaroundNewWindowFlash 25% Release

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2861,7 +2861,7 @@
                         ]
                     },
                     "name": "Enabled",
-                    "probability_weight": 0
+                    "probability_weight": 25
                 },
                 {
                     "feature_association": {
@@ -2870,7 +2870,7 @@
                         ]
                     },
                     "name": "Disabled",
-                    "probability_weight": 100
+                    "probability_weight": 75
                 },
                 {
                     "name": "Default",


### PR DESCRIPTION
1.70.x is now Release, so we can continue rolling this feature. It's already enabled by default in Nightly and Beta.

Related https://github.com/brave/brave-variations/pull/1178

