### PR TITLE
Disable BraveRoundTimeStamps (5% Release)

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2948,6 +2948,67 @@
                 ]
             },
             "name": "BraveWebcompatExceptionsServiceReleaseStudy"
+        },
+        {
+            "experiments": [
+                {
+                    "feature_association": {
+                        "disable_feature": [
+                            "BraveRoundTimeStamps"
+                        ]
+                    },
+                    "name": "Disabled",
+                    "probability_weight": 100
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 0
+                }
+            ],
+            "filter": {
+                "channel": [
+                    "NIGHTLY",
+                    "BETA"
+                ],
+                "min_version": "125.*",
+                "platform": [
+                    "WINDOWS",
+                    "MAC",
+                    "LINUX",
+                    "ANDROID"
+                ]
+            },
+            "name": "BraveRoundTimeStampsStudy"
+        },
+        {
+            "experiments": [
+                {
+                    "feature_association": {
+                        "disable_feature": [
+                            "BraveRoundTimeStamps"
+                        ]
+                    },
+                    "name": "Disabled",
+                    "probability_weight": 5
+                },
+                {
+                    "name": "Default",
+                    "probability_weight": 95
+                }
+            ],
+            "filter": {
+                "channel": [
+                    "RELEASE"
+                ],
+                "min_version": "125.*",
+                "platform": [
+                    "WINDOWS",
+                    "MAC",
+                    "LINUX",
+                    "ANDROID"
+                ]
+            },
+            "name": "BraveRoundTimeStampsReleaseStudy"
         }
     ],
     "version": "1"


### PR DESCRIPTION
Resolves https://github.com/brave/brave-variations/issues/1214

Nightly & Beta: 100%
Release: 5%

Disabling the feature just returns the code to the upstream state, so it's relatively safe.
Just to be sure let's start with 5% now and go to 100% the new day.