### PR TITLE
[ads] Disable CustomNotificationAdsStudy study

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1758,35 +1758,6 @@
             "experiments": [
                 {
                     "feature_association": {
-                        "enable_feature": [
-                            "CustomNotificationAds"
-                        ]
-                    },
-                    "name": "Enabled",
-                    "probability_weight": 100
-                },
-                {
-                    "name": "Default",
-                    "probability_weight": 0
-                }
-            ],
-            "filter": {
-                "channel": [
-                    "NIGHTLY",
-                    "BETA"
-                ],
-                "min_version": "115.1.58.35",
-                "platform": [
-                    "WINDOWS",
-                    "MAC"
-                ]
-            },
-            "name": "CustomNotificationAdsStudy"
-        },
-        {
-            "experiments": [
-                {
-                    "feature_association": {
                         "disable_feature": [
                             "PrettyPrintJSONDocument"
                         ]


### PR DESCRIPTION
The `CustomNotificationAdsStudy` study is disabled now to ensure push notification ads function consistently across Nightly, Beta, and Release channels (the study was enabled for Nightly and Beta only).