### PR TITLE
Enable BraveWorkaroundNewWindowFlash 100% Release.

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2832,7 +2832,7 @@
                         ]
                     },
                     "name": "Enabled",
-                    "probability_weight": 25
+                    "probability_weight": 100
                 },
                 {
                     "feature_association": {
@@ -2841,7 +2841,7 @@
                         ]
                     },
                     "name": "Disabled",
-                    "probability_weight": 75
+                    "probability_weight": 0
                 },
                 {
                     "name": "Default",


### PR DESCRIPTION
1.70.x is now Release, so we can continue rolling this feature. It's already enabled by default in Nightly and Beta.

Related https://github.com/brave/brave-variations/pull/1178

