### PR TITLE
Disable BraveRoundTimeStamps Release 25%

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -2960,11 +2960,11 @@
                         ]
                     },
                     "name": "Disabled",
-                    "probability_weight": 5
+                    "probability_weight": 25
                 },
                 {
                     "name": "Default",
-                    "probability_weight": 95
+                    "probability_weight": 75
                 }
             ],
             "filter": {


### PR DESCRIPTION
For https://github.com/brave/brave-variations/issues/1214

According to backtrace.io data disabling the feature helps:
Default (95%), `ebc44611-ca7d8d80`, still crashes on Spotify: 
https://share.backtrace.io/api/share/5yTIx1x1ZTzUOoi6K0VApLn3

Disabled (5%), `ebc44611-3d47f4f4`, only few crashes a day, no RequestIdeCallback crashes: 
https://share.backtrace.io/api/share/HWOa9G64FZWfx3SLx1Ks8hg2
