### PR TITLE
Set Leo default model to Llama 3 8b (25% rollout)

### DIFF
--- a/seed/seed.json
+++ b/seed/seed.json
@@ -1789,6 +1789,7 @@
                     "RELEASE"
                 ],
                 "min_version": "119.1.60.0",
+                "max_version": "122.0.6261.56",
                 "platform": [
                     "WINDOWS",
                     "MAC",

--- a/seed/seed.json
+++ b/seed/seed.json
@@ -9,11 +9,12 @@
                         ]
                     },
                     "name": "DefaultLlama",
-                    "params": {
-                        "AIChat": {
-                            "default_model": "chat-basic"
+                    "parameters": [
+                        {
+                            "name": "default_model",
+                            "value": "chat-basic"
                         }
-                    },
+                    ],
                     "probability_weight": 25
                 },
                 {

--- a/seed/seed.json
+++ b/seed/seed.json
@@ -5,6 +5,49 @@
                 {
                     "feature_association": {
                         "enable_feature": [
+                            "AIChat"
+                        ]
+                    },
+                    "name": "DefaultLlama",
+                    "params": {
+                        "AIChat": {
+                            "default_model": "chat-basic"
+                        }
+                    },
+                    "probability_weight": 25
+                },
+                {
+                    "feature_association": {
+                        "enable_feature": [
+                            "AIChat"
+                        ]
+                    },
+                    "name": "DefaultMixtral",
+                    "probability_weight": 75
+                }
+            ],
+            "filter": {
+                "channel": [
+                    "RELEASE",
+                    "BETA",
+                    "NIGHTLY"
+                ],
+                "min_version": "122.0.6261.57",
+                "platform": [
+                    "WINDOWS",
+                    "MAC",
+                    "LINUX",
+                    "ANDROID",
+                    "IOS"
+                ]
+            },
+            "name": "BraveAIChatDefaultModelStudy"
+        },
+        {
+            "experiments": [
+                {
+                    "feature_association": {
+                        "enable_feature": [
                             "BraveAdblockDefault1pBlocking"
                         ]
                     },

--- a/seed/seed.json
+++ b/seed/seed.json
@@ -5,50 +5,6 @@
                 {
                     "feature_association": {
                         "enable_feature": [
-                            "AIChat"
-                        ]
-                    },
-                    "name": "DefaultLlama",
-                    "parameters": [
-                        {
-                            "name": "default_model",
-                            "value": "chat-basic"
-                        }
-                    ],
-                    "probability_weight": 25
-                },
-                {
-                    "feature_association": {
-                        "enable_feature": [
-                            "AIChat"
-                        ]
-                    },
-                    "name": "DefaultMixtral",
-                    "probability_weight": 75
-                }
-            ],
-            "filter": {
-                "channel": [
-                    "RELEASE",
-                    "BETA",
-                    "NIGHTLY"
-                ],
-                "min_version": "122.1.63.161",
-                "platform": [
-                    "WINDOWS",
-                    "MAC",
-                    "LINUX",
-                    "ANDROID",
-                    "IOS"
-                ]
-            },
-            "name": "BraveAIChatDefaultModelStudy"
-        },
-        {
-            "experiments": [
-                {
-                    "feature_association": {
-                        "enable_feature": [
                             "BraveAdblockDefault1pBlocking"
                         ]
                     },
@@ -1790,7 +1746,6 @@
                     "RELEASE"
                 ],
                 "min_version": "119.1.60.0",
-                "max_version": "122.1.63.160",
                 "platform": [
                     "WINDOWS",
                     "MAC",

--- a/seed/seed.json
+++ b/seed/seed.json
@@ -32,7 +32,7 @@
                     "BETA",
                     "NIGHTLY"
                 ],
-                "min_version": "122.0.6261.57",
+                "min_version": "122.1.63.161",
                 "platform": [
                     "WINDOWS",
                     "MAC",
@@ -1789,7 +1789,7 @@
                     "RELEASE"
                 ],
                 "min_version": "119.1.60.0",
-                "max_version": "122.0.6261.56",
+                "max_version": "122.1.63.160",
                 "platform": [
                     "WINDOWS",
                     "MAC",

--- a/studies/BraveAIChatDefaultModelStudy.json5
+++ b/studies/BraveAIChatDefaultModelStudy.json5
@@ -1,0 +1,46 @@
+[
+  {
+    name: 'BraveAIChatDefaultModelStudy',
+    experiment: [
+      {
+        name: 'DefaultLlama',
+        probability_weight: 25,
+        feature_association: {
+          enable_feature: [
+            'AIChat',
+          ],
+        },
+        param: [
+          {
+            name: 'default_model',
+            value: 'chat-basic',
+          },
+        ],
+      },
+      {
+        name: 'DefaultMixtral',
+        probability_weight: 75,
+        feature_association: {
+          enable_feature: [
+            'AIChat',
+          ],
+        },
+      },
+    ],
+    filter: {
+      min_version: '122.1.63.161',
+      channel: [
+        'RELEASE',
+        'BETA',
+        'NIGHTLY',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+        'ANDROID',
+        'IOS',
+      ],
+    },
+  },
+]

--- a/studies/BraveAIChatEnabledStudy.json5
+++ b/studies/BraveAIChatEnabledStudy.json5
@@ -18,6 +18,7 @@
     ],
     filter: {
       min_version: '119.1.60.0',
+      max_version: '122.1.63.160',
       channel: [
         'RELEASE',
       ],


### PR DESCRIPTION
Related to https://github.com/brave/brave-core/pull/21398
Blocked on deploying https://github.com/brave/aichat-ops/pull/359 to prod

This sets the default model for 25% of free users to `chat-basic`, which corresponds to [Llama 3 8b](https://github.com/brave/brave-core/blob/c839e1676031a3d155b04b9dbfe49e11b3b8601b/components/ai_chat/core/browser/model_service.cc#L154).

The intention is to start this to progressively roll out this change (25%, 50%, 75%, 100%), so we can ensure our single instance of Llama 3 can handle the increase in traffic.  Based on these [estimations](https://artificialanalysis.ai/?models_selected=llama-3-1-instruct-8b%2Cmixtral-8x7b-instruct), one instance of llama 3 (one gpu) should have higher token throughput than our single instance of mixtral (four gpus), so we expect this to work with two llama instances which will be added in https://github.com/brave/aichat-ops/pull/359.

cc @petemill @LorenzoMinto

Note:
* Chromium version 122.0.6261.57 was selected because that was the first chromium version when 1.63.x was released (see https://bravesoftware.slack.com/archives/C04PX1BUN/p1708629893634639), which is when https://github.com/brave/brave-core/pull/21398 went in.
* I have included all platforms because we want to make this change across all platforms, however this does differ from the BraveAIChatEnabledStudy which applies only to desktop