### PR TITLE
Default to `studies` dir and `seed.bin` output file.

### DIFF
--- a/src/scripts/lint.ts
+++ b/src/scripts/lint.ts
@@ -41,8 +41,8 @@ function getLintAllCommands(options: Options): string[] {
   return [
     'prettier . --ignore-unknown' + (options.fix ? ' --write' : ' --check'),
     'eslint . --config src/.eslintrc.js' + (options.fix ? ' --fix' : ''),
-    // TODO(goodov): Add a command to lint JSON studies when per-file structure
-    // appears.
+    // TODO(goodov): Enable when per-file structure appears.
+    // 'npm run seed_tools lint --' + (options.fix ? ' --fix' : ''),
   ];
 }
 
@@ -53,7 +53,7 @@ function getLintDiffCommands(options: Options): Record<string, any> {
     '*.{ts,js,tsx,jsx}':
       'eslint --config src/.eslintrc.js' + (options.fix ? ' --fix' : ''),
     'studies/*': () =>
-      'npm run seed_tools -- lint studies' + (options.fix ? ' --fix' : ''),
+      'npm run seed_tools lint --' + (options.fix ? ' --fix' : ''),
   };
 }
 

--- a/src/seed_tools/commands/create.ts
+++ b/src/seed_tools/commands/create.ts
@@ -12,8 +12,12 @@ import { readStudiesToSeed } from '../utils/studies_to_seed';
 export default function createCommand() {
   return new Command('create')
     .description('Create seed.bin from study files')
-    .argument('<studies_dir>', 'path to the directory containing study files')
-    .argument('<output_seed_file>', 'output seed file')
+    .argument(
+      '[studies_dir]',
+      'path to the directory containing study files',
+      'studies',
+    )
+    .argument('[output_seed_file]', 'output seed file', 'seed.bin')
     .option('--mock_serial_number <value>', 'mock serial number')
     .option(
       '--output_serial_number_file <path>',

--- a/src/seed_tools/commands/lint.ts
+++ b/src/seed_tools/commands/lint.ts
@@ -9,7 +9,11 @@ import { readStudiesToSeed } from '../utils/studies_to_seed';
 export default function createCommand() {
   return new Command('lint')
     .description('Lint study files without creating seed.bin')
-    .argument('<studies_dir>', 'path to the directory containing study files')
+    .argument(
+      '[studies_dir]',
+      'path to the directory containing study files',
+      'studies',
+    )
     .option('--fix', 'fix format errors in-place')
     .action(lintStudies);
 }


### PR DESCRIPTION
Use sane defaults to be able to call `seed_tools create` and `seed_tools lint` without any parameters.