### PR TITLE
Add compare_python_gen helper.

### DIFF
--- a/src/seed_tools/commands/compare_python_gen.ts
+++ b/src/seed_tools/commands/compare_python_gen.ts
@@ -15,15 +15,10 @@ export default function createCommand() {
     .description(
       'Run python and typescript seed generators and compare results',
     )
-    .option('--python <value>', 'Path to python executable', 'python3')
     .action(main);
 }
 
-interface Options {
-  python: string;
-}
-
-async function main(options: Options) {
+async function main() {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'seed-compare-'));
   const mockSerialNumber = 'mock_serial_number';
 
@@ -41,7 +36,7 @@ async function main(options: Options) {
 
     // Run Python seed generator
     execSync(
-      `${options.python} ./seed/serialize.py ./seed/seed.json --mock_serial_number ${mockSerialNumber}`,
+      `python3 ./seed/serialize.py ./seed/seed.json --mock_serial_number ${mockSerialNumber}`,
       {
         stdio: 'inherit',
       },

--- a/src/seed_tools/commands/compare_python_gen.ts
+++ b/src/seed_tools/commands/compare_python_gen.ts
@@ -58,7 +58,7 @@ async function main(options: Options) {
 
     // Run seed comparator
     execSync(
-      `npm run seed_tools compare_seeds ${pythonSeedFilePath} ${typescriptSeedFilePath} ${pythonSeedSerialNumberFilePath} ${typescriptSeedSerialNumberFilePath}`,
+      `npm run seed_tools compare_seeds ${pythonSeedFilePath} ${typescriptSeedFilePath} --seed1_serialnumber_file ${pythonSeedSerialNumberFilePath} --seed2_serialnumber_file ${typescriptSeedSerialNumberFilePath}`,
       { stdio: 'inherit' },
     );
   } finally {

--- a/src/seed_tools/commands/compare_python_gen.ts
+++ b/src/seed_tools/commands/compare_python_gen.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { Command } from '@commander-js/extra-typings';
+import { execSync } from 'child_process';
+import { assert } from 'console';
+import { existsSync, promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+export default function createCommand() {
+  return new Command('compare_python_gen')
+    .description(
+      'Run python and typescript seed generators and compare results',
+    )
+    .option('--python <value>', 'Path to python executable', 'python3')
+    .action(main);
+}
+
+interface Options {
+  python: string;
+}
+
+async function main(options: Options) {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'seed-compare-'));
+  const mockSerialNumber = 'mock_serial_number';
+
+  try {
+    const pythonSeedFilePath = path.join(tempDir, 'python_seed.bin');
+    const typescriptSeedFilePath = path.join(tempDir, 'typescript_seed.bin');
+    const pythonSeedSerialNumberFilePath = path.join(
+      tempDir,
+      'python_serialnumber',
+    );
+    const typescriptSeedSerialNumberFilePath = path.join(
+      tempDir,
+      'typescript_serialnumber',
+    );
+
+    // Run Python seed generator
+    execSync(
+      `${options.python} ./seed/serialize.py ./seed/seed.json --mock_serial_number ${mockSerialNumber}`,
+      {
+        stdio: 'inherit',
+      },
+    );
+    // Move generated seed.bin and serialnumber to temporary directory.
+    await moveFile('./seed.bin', pythonSeedFilePath);
+    await moveFile('./serialnumber', pythonSeedSerialNumberFilePath);
+
+    // Run TypeScript seed generator
+    execSync(
+      `npm run seed_tools create ./studies ${typescriptSeedFilePath} -- --mock_serial_number ${mockSerialNumber} --output_serial_number_file ${typescriptSeedSerialNumberFilePath}`,
+      { stdio: 'inherit' },
+    );
+
+    // Run seed comparator
+    execSync(
+      `npm run seed_tools compare_seeds ${pythonSeedFilePath} ${typescriptSeedFilePath} ${pythonSeedSerialNumberFilePath} ${typescriptSeedSerialNumberFilePath}`,
+      { stdio: 'inherit' },
+    );
+  } finally {
+    // Clean up temporary directory
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function moveFile(src: string, dest: string) {
+  await fs.copyFile(src, dest);
+  await fs.unlink(src);
+  assert(!existsSync(src));
+}

--- a/src/seed_tools/commands/compare_seeds.ts
+++ b/src/seed_tools/commands/compare_seeds.ts
@@ -13,16 +13,20 @@ export default function createCommand() {
     .description('Compare two seed.bin')
     .argument('<seed1_file>', 'seed1 file')
     .argument('<seed2_file>', 'seed2 file')
-    .argument('<seed1_serialnumber>', 'seed1 serialnumber file')
-    .argument('<seed2_serialnumber>', 'seed2 serialnumber file')
+    .option('--seed1_serialnumber_file <file>', 'seed1 serialnumber file')
+    .option('--seed2_serialnumber_file <file>', 'seed2 serialnumber file')
     .action(main);
+}
+
+interface Options {
+  seed1_serialnumber_file?: string;
+  seed2_serialnumber_file?: string;
 }
 
 async function main(
   seed1FilePath: string,
   seed2FilePath: string,
-  seed1SerialnumberFilePath: string,
-  seed2SerialnumberFilePath: string,
+  options: Options,
 ) {
   const seed1Binary: Buffer = await fs.readFile(seed1FilePath);
   const seed2Binary: Buffer = await fs.readFile(seed2FilePath);
@@ -62,21 +66,26 @@ async function main(
     process.exit(1);
   }
 
-  const seed1Serialnumber: string = await fs.readFile(
-    seed1SerialnumberFilePath,
-    'utf8',
-  );
-  const seed2Serialnumber: string = await fs.readFile(
-    seed2SerialnumberFilePath,
-    'utf8',
-  );
-  if (seed1Content.serial_number !== seed1Serialnumber) {
-    console.error('Seed1 serial number does not match');
-    process.exit(1);
+  if (options.seed1_serialnumber_file !== undefined) {
+    const seed1Serialnumber: string = await fs.readFile(
+      options.seed1_serialnumber_file,
+      'utf8',
+    );
+    if (seed1Content.serial_number !== seed1Serialnumber) {
+      console.error('Seed1 serial number does not match');
+      process.exit(1);
+    }
   }
-  if (seed2Content.serial_number !== seed2Serialnumber) {
-    console.error('Seed2 serial number does not match');
-    process.exit(1);
+
+  if (options.seed2_serialnumber_file !== undefined) {
+    const seed2Serialnumber: string = await fs.readFile(
+      options.seed2_serialnumber_file,
+      'utf8',
+    );
+    if (seed2Content.serial_number !== seed2Serialnumber) {
+      console.error('Seed2 serial number does not match');
+      process.exit(1);
+    }
   }
 
   console.log('Seeds are equal');

--- a/src/seed_tools/commands/create.test.ts
+++ b/src/seed_tools/commands/create.test.ts
@@ -101,6 +101,35 @@ describe('create command', () => {
     );
   });
 
+  describe('serial number is equal in the seed and in the generated file', () => {
+    const validSeedsDir = path.join(testDataDir, 'valid_seeds');
+    it.each(fs_sync.readdirSync(validSeedsDir))(
+      'correctly creates %s',
+      async (testCase) => {
+        const testCaseDir = path.join(validSeedsDir, testCase);
+        const studiesDir = path.join(testCaseDir, 'studies');
+        const outputFile = path.join(tempDir, 'output.bin');
+        const serialNumberPath = path.join(tempDir, 'serial_number.txt');
+
+        await create().parseAsync([
+          'node',
+          'create',
+          studiesDir,
+          outputFile,
+          '--output_serial_number_file',
+          serialNumberPath,
+        ]);
+
+        const output = await fs.readFile(outputFile);
+        const outputSerialNumber = await fs.readFile(serialNumberPath, 'utf-8');
+        expect(outputSerialNumber).not.toEqual('1');
+        expect(VariationsSeed.fromBinary(output).serial_number).toEqual(
+          outputSerialNumber,
+        );
+      },
+    );
+  });
+
   describe('invalid studies', () => {
     const invalidStudiesDir = path.join(testDataDir, 'invalid_studies');
     it.each(fs_sync.readdirSync(invalidStudiesDir))(
@@ -117,8 +146,6 @@ describe('create command', () => {
             'create',
             studiesDir,
             outputFile,
-            '--mock_serial_number',
-            '1',
             '--output_serial_number_file',
             serialNumberPath,
           ]),
@@ -143,8 +170,6 @@ describe('create command', () => {
             'create',
             studiesDir,
             outputFile,
-            '--mock_serial_number',
-            '1',
             '--output_serial_number_file',
             serialNumberPath,
           ]),

--- a/src/seed_tools/seed_tools.ts
+++ b/src/seed_tools/seed_tools.ts
@@ -5,6 +5,7 @@
 
 import { program } from '@commander-js/extra-typings';
 
+import compare_python_gen from './commands/compare_python_gen';
 import compare_seeds from './commands/compare_seeds';
 import create from './commands/create';
 import lint from './commands/lint';
@@ -13,6 +14,7 @@ import split_seed_json from './commands/split_seed_json';
 program
   .name('seed_tools')
   .description('Seed tools for manipulating study files.')
+  .addCommand(compare_python_gen())
   .addCommand(compare_seeds())
   .addCommand(create())
   .addCommand(lint())


### PR DESCRIPTION
Add a helper command to run both python and TS generators to compare their outputs.

Tested on staging CI runs https://ci.brave.com/job/brave-browser-variations-publish-staging/1997/