### PR TITLE
Ignore dot directories except .github in prettier.

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,5 @@
+/.*/**
+!/.github/**
 seed/seed.json
 src/proto/generated/*
 src/test/data/**/*unformatted*


### PR DESCRIPTION
Avoid formatting dirs such as `.vscode` and others that are not part of the repo.

```
20:54:11  Checking formatting...
20:54:12  [warn] .pyenv-python3/lib/python3.10/site-packages/argparse-1.4.0.dist-info/metadata.json
20:54:16  [warn] Code style issues found in the above file. Run Prettier with --write to fix.
```