### PR TITLE
Rollout Llama as default model to 75% of users (2)

### DIFF
--- a/studies/BraveAIChatDefaultModelStudy.json5
+++ b/studies/BraveAIChatDefaultModelStudy.json5
@@ -4,7 +4,7 @@
     experiment: [
       {
         name: 'DefaultLlama',
-        probability_weight: 25,
+        probability_weight: 75,
         feature_association: {
           enable_feature: [
             'AIChat',
@@ -19,7 +19,7 @@
       },
       {
         name: 'DefaultMixtral',
-        probability_weight: 75,
+        probability_weight: 25,
         feature_association: {
           enable_feature: [
             'AIChat',


### PR DESCRIPTION
Previous pr https://github.com/brave/brave-variations/pull/1255, actually reduced llama to 25% by mistake.