### PR TITLE
Add DayZeroStudy for android in release channel

### DIFF
--- a/studies/DayZeroStudyAndroid.json5
+++ b/studies/DayZeroStudyAndroid.json5
@@ -4,7 +4,7 @@
     experiment: [
       {
         name: 'EnabledA',
-        probability_weight: 50,
+        probability_weight: 4,
         feature_association: {
           enable_feature: [
             'BraveDayZeroExperiment',
@@ -19,7 +19,7 @@
       },
       {
         name: 'EnabledB',
-        probability_weight: 50,
+        probability_weight: 4,
         feature_association: {
           enable_feature: [
             'BraveDayZeroExperiment',
@@ -34,7 +34,7 @@
       },
       {
         name: 'Default',
-        probability_weight: 0,
+        probability_weight: 92,
       },
     ],
     filter: {

--- a/studies/DayZeroStudyAndroid.json5
+++ b/studies/DayZeroStudyAndroid.json5
@@ -1,0 +1,49 @@
+[
+  {
+    name: 'DayZeroStudyAndroid',
+    experiment: [
+      {
+        name: 'EnabledA',
+        probability_weight: 50,
+        feature_association: {
+          enable_feature: [
+            'BraveDayZeroExperiment',
+          ],
+        },
+        param: [
+          {
+            name: 'variant',
+            value: 'a',
+          },
+        ],
+      },
+      {
+        name: 'EnabledB',
+        probability_weight: 50,
+        feature_association: {
+          enable_feature: [
+            'BraveDayZeroExperiment',
+          ],
+        },
+        param: [
+          {
+            name: 'variant',
+            value: 'b',
+          },
+        ],
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      channel: [
+        'RELEASE',
+      ],
+      platform: [
+        'ANDROID',
+      ],
+    },
+  },
+]

--- a/studies/DayZeroStudyAndroid.json5
+++ b/studies/DayZeroStudyAndroid.json5
@@ -38,6 +38,7 @@
       },
     ],
     filter: {
+      min_version: '131.1.73.91',
       channel: [
         'RELEASE',
       ],


### PR DESCRIPTION
We need to add DayZeroStudy to A/B test new onboarding changes here : https://github.com/brave/brave-core/pull/26193