### PR TITLE
Enable Shred on iOS all channels

### DIFF
--- a/studies/BraveShredFeatureStudy.json5
+++ b/studies/BraveShredFeatureStudy.json5
@@ -1,0 +1,32 @@
+[
+  {
+    name: 'BraveShredFeatureStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 100,
+        feature_association: {
+          enable_feature: [
+            'BraveShredFeature',
+            'BraveShredCacheData',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      min_version: '130.*',
+      channel: [
+        'RELEASE',
+        'BETA',
+        'NIGHTLY',
+      ],
+      platform: [
+        'IOS',
+      ],
+    },
+  },
+]


### PR DESCRIPTION
Fixes https://github.com/brave/brave-variations/issues/1260

Enabled for Chromium `130.*` which released with v1.71 on iOS to not enable for existing releases which included some Shred code behind the feature flag(s).