### PR TITLE
Add slack channel ID to finch tracker config

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -31,6 +31,8 @@ module.exports = {
     'VulkanVMALargeHeapBlockSizeExperiment',
   ],
 
+  channelId: 'C05S50MFHPE', // #finch-updates
+
   // Add your slack ID to get notifications about new kill switches.
   // To retrive it use Slack profile => Copy Member ID.
   killSwitchNotificationIds: [

--- a/src/core/summary.ts
+++ b/src/core/summary.ts
@@ -361,6 +361,7 @@ export function summaryToJson(
     );
   }
   return `{
+    "channel" : "${config.channelId}",
     "text": "New finch changes detected",
     "blocks": [
       ${output.toString()}


### PR DESCRIPTION
We need to pass channel to support slack-github-action v2 in the tracker job (https://github.com/brave/finch-data-private/pull/19/files)