### PR TITLE
Fix processed study comparison

### DIFF
--- a/src/core/study_processor.ts
+++ b/src/core/study_processor.ts
@@ -106,6 +106,17 @@ export class ProcessedStudy {
     this.postProcessStudy(options);
   }
 
+  equals(other: ProcessedStudy): boolean {
+    const jsonEquals = (a: unknown, b: unknown) =>
+      JSON.stringify(a) === JSON.stringify(b);
+
+    return (
+      Study.equals(this.study, other.study) &&
+      jsonEquals(this.studyDetails, other.studyDetails) &&
+      jsonEquals(this.affectedFeatures, other.affectedFeatures)
+    );
+  }
+
   getPriority(): StudyPriority {
     return this.studyDetails.getPriority();
   }

--- a/src/core/summary.ts
+++ b/src/core/summary.ts
@@ -132,7 +132,9 @@ export function makeSummary(
 
     const oldStudy: ProcessedStudy[] = oldMap.get(key) ?? [];
     const newStudy: ProcessedStudy[] = newMap.get(key) ?? [];
-    const isChanged = JSON.stringify(oldStudy) !== JSON.stringify(newStudy);
+    const isEqual =
+      oldStudy.length == newStudy.length &&
+      oldStudy.every((v, i) => v.equals(newStudy[i]));
 
     const item = new SummaryItem();
     item.oldPriority = getOverallPriority(oldStudy);
@@ -170,7 +172,7 @@ export function makeSummary(
         item.action = ItemAction.Down;
       }
     } else {
-      if (isChanged) {
+      if (!isEqual) {
         item.action = ItemAction.Change;
       } else {
         return;

--- a/src/finch_tracker/tracker_lib.test.ts
+++ b/src/finch_tracker/tracker_lib.test.ts
@@ -62,6 +62,8 @@ describe('summary', () => {
     filter: {
       channel: [Study_Channel.STABLE],
       platform: [Study_Platform.WINDOWS],
+      start_date: BigInt(Math.floor(new Date().getTime() / 1000) - 1000),
+      end_date: BigInt(Math.floor(new Date().getTime() / 1000) + 1000),
     },
   };
   const oldStudy = Study.create({


### PR DESCRIPTION
Fix generating summary:
`JSON.stringify` can't deal with BigInt.

The test covered this part of code, but they didn't have any bigInt field.