### PR TITLE
Enabled brave search promotion button study for CA/GB in beta/nightly

### DIFF
--- a/studies/BraveSearchPromotionBannerStudy.json5
+++ b/studies/BraveSearchPromotionBannerStudy.json5
@@ -60,10 +60,8 @@
         'LINUX',
       ],
       country: [
-        'CA',
         'DE',
         'FR',
-        'GB',
         'US',
         'AT',
         'ES',

--- a/studies/BraveSearchPromotionButtonStudy.json5
+++ b/studies/BraveSearchPromotionButtonStudy.json5
@@ -1,0 +1,36 @@
+[
+  {
+    name: 'BraveSearchPromotionButtonStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 100,
+        feature_association: {
+          enable_feature: [
+            'BraveSearchPromotionOmniboxButton',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      min_version: '131.1.74.20',
+      channel: [
+        'BETA',
+        'NIGHTLY',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+      ],
+      country: [
+        'CA',
+        'GB',
+      ],
+    },
+  },
+]


### PR DESCRIPTION
Related issue - https://github.com/brave/brave-browser/issues/40776

also removed CA/GB from search promotion banner study.