### PR TITLE
Add iOS new menu study for Nightly/Beta

### DIFF
--- a/studies/NewiOSMenuUIStudy.json5
+++ b/studies/NewiOSMenuUIStudy.json5
@@ -1,0 +1,29 @@
+[
+  {
+    name: 'NewiOSMenuUIStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 100,
+        feature_association: {
+          enable_feature: [
+            'ModernBrowserMenuEnabled',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      channel: [
+        'NIGHTLY',
+        'BETA',
+      ],
+      platform: [
+        'IOS',
+      ],
+    },
+  },
+]


### PR DESCRIPTION
Related issue: https://github.com/brave/brave-browser/issues/42836

Only actually in nightly at the moment but would like to have it available in beta once channel migration occurs