### PR TITLE
Add study for Rewards 3.0 UI and enable in Beta and Nightly

### DIFF
--- a/studies/BraveRewardsNewRewardsUIStudy.json5
+++ b/studies/BraveRewardsNewRewardsUIStudy.json5
@@ -1,0 +1,31 @@
+[
+  {
+    name: 'BraveRewardsNewRewardsUIStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 100,
+        feature_association: {
+          enable_feature: [
+            'BraveRewardsNewRewardsUI',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      channel: [
+        'NIGHTLY',
+        'BETA',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+      ],
+    },
+  },
+]


### PR DESCRIPTION
Add study for Rewards 3.0 UI (feature name "BraveRewardsNewRewardsUI") and enable in Beta and Nightly.