### PR TITLE
Set Rewards 3.0 to 0% on Release

### DIFF
--- a/studies/BraveRewardsNewRewardsUIStudy.json5
+++ b/studies/BraveRewardsNewRewardsUIStudy.json5
@@ -33,7 +33,7 @@
     experiment: [
       {
         name: 'Enabled',
-        probability_weight: 25,
+        probability_weight: 0,
         feature_association: {
           enable_feature: [
             'BraveRewardsNewRewardsUI',
@@ -42,7 +42,7 @@
       },
       {
         name: 'Default',
-        probability_weight: 75,
+        probability_weight: 100,
       },
     ],
     filter: {


### PR DESCRIPTION
Sets Rewards 3.0 to 0% on Release until a security/privacy review for WDP onboarding is completed.