### PR TITLE
Update HangWatcher config

### DIFF
--- a/studies/HangWatcher.json5
+++ b/studies/HangWatcher.json5
@@ -4,7 +4,7 @@
     experiment: [
       {
         name: 'HangWatcherEnableDumps',
-        probability_weight: 50,
+        probability_weight: 100,
         feature_association: {
           enable_feature: [
             'EnableHangWatcher',
@@ -19,38 +19,18 @@
             name: 'io_thread_log_level',
             value: '2',
           },
-          {
-            name: 'renderer_process_main_thread_log_level',
-            value: '2',
-          },
-          {
-            name: 'renderer_process_io_thread_log_level',
-            value: '2',
-          },
-          {
-            name: 'utility_process_main_thread_log_level',
-            value: '2',
-          },
-          {
-            name: 'utility_process_io_thread_log_level',
-            value: '2',
-          },
         ],
-      },
-      {
-        name: 'Default',
-        probability_weight: 50,
       },
     ],
     filter: {
       min_version: '97.1.36.14',
       channel: [
         'NIGHTLY',
+        'BETA',
       ],
       platform: [
         'WINDOWS',
         'MAC',
-        'LINUX',
       ],
     },
   },


### PR DESCRIPTION
The PR changes the config for `HangWatcher` that sends a report to backtrace in unexpected hangs:
* disables `HangWatcher` on Linux (too noisy, hangs in OS-level libs that we can't fix)
* focus on the main process, disable the other process. Hangs for that processes are acceptable and happens in Chromium from time to time. Right now we don't have an instrument to split expected hangs from unwanted. 
* enables the feature for 100% of Beta & Nightly