### PR TITLE
Enable new menu on Release (15%)

### DIFF
--- a/studies/NewiOSMenuUIStudy.json5
+++ b/studies/NewiOSMenuUIStudy.json5
@@ -26,4 +26,30 @@
       ],
     },
   },
+  {
+    name: 'NewiOSMenuUIStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 15,
+        feature_association: {
+          enable_feature: [
+            'ModernBrowserMenuEnabled',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 85,
+      },
+    ],
+    filter: {
+      channel: [
+        'RELEASE',
+      ],
+      platform: [
+        'IOS',
+      ],
+    },
+  },
 ]


### PR DESCRIPTION
Adds a griffin study for enabling the new menu on iOS on Release builds, phased at 15%