### PR TITLE
Set new menu rollout on iOS to 50%

### DIFF
--- a/studies/NewiOSMenuUIStudy.json5
+++ b/studies/NewiOSMenuUIStudy.json5
@@ -31,7 +31,7 @@
     experiment: [
       {
         name: 'Enabled',
-        probability_weight: 15,
+        probability_weight: 50,
         feature_association: {
           enable_feature: [
             'ModernBrowserMenuEnabled',
@@ -40,7 +40,7 @@
       },
       {
         name: 'Default',
-        probability_weight: 85,
+        probability_weight: 50,
       },
     ],
     filter: {


### PR DESCRIPTION
1.75 is fully rolled out now and we haven't heard any negative feedback on the new menu yet