### PR TITLE
[iOS] - Set BraveTranslate iOS Release to 15%

### DIFF
--- a/studies/BraveTranslateiOSStudy.json5
+++ b/studies/BraveTranslateiOSStudy.json5
@@ -26,4 +26,30 @@
       ],
     },
   },
+  {
+    name: 'BraveTranslateiOSStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 15,
+        feature_association: {
+          enable_feature: [
+            'BraveTranslateEnabled',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 85,
+      },
+    ],
+    filter: {
+      channel: [
+        'RELEASE',
+      ],
+      platform: [
+        'IOS',
+      ],
+    },
+  },
 ]


### PR DESCRIPTION
## Summary
- Update Brave Translate for iOS to 15% on Release

Fixes: https://github.com/brave/brave-variations/issues/1330