### PR TITLE
Add YouTube script injector study for Android

### DIFF
--- a/studies/AndroidYouTubeScriptInjectorStudy.json5
+++ b/studies/AndroidYouTubeScriptInjectorStudy.json5
@@ -1,6 +1,6 @@
 [
   {
-    name: 'AndroidYouTubeScriptInjectorStudy',
+    name: 'AndroidYouTubeScriptInjectorStudy_Component',
     experiment: [
       {
         name: 'Enabled',

--- a/studies/AndroidYouTubeScriptInjectorStudy.json5
+++ b/studies/AndroidYouTubeScriptInjectorStudy.json5
@@ -1,0 +1,86 @@
+[
+  {
+    name: 'AndroidYouTubeScriptInjectorStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 100,
+        feature_association: {
+          enable_feature: [
+            'BraveYouTubeScriptInjector',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      channel: [
+        'RELEASE',
+        'BETA',
+        'NIGHTLY',
+      ],
+      platform: [
+        'ANDROID',
+      ],
+    },
+  },
+  {
+    name: 'AndroidYouTubeScriptInjectorStudy_VideoPlayback',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 100,
+        feature_association: {
+          enable_feature: [
+            'BraveBackgroundVideoPlayback',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      channel: [
+        'RELEASE',
+        'BETA',
+        'NIGHTLY',
+      ],
+      platform: [
+        'ANDROID',
+      ],
+    },
+  },
+  {
+    name: 'AndroidYouTubeScriptInjectorStudy_ExtraControls',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 100,
+        feature_association: {
+          enable_feature: [
+            'BraveYouTubeExtraControls',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      channel: [
+        'RELEASE',
+        'BETA',
+        'NIGHTLY',
+      ],
+      platform: [
+        'ANDROID',
+      ],
+    },
+  },
+]


### PR DESCRIPTION
**NOTE**: this variations change is contingent on the code landing (see https://github.com/brave/brave-core/pull/26355). The `BraveYouTubeScriptInjector` feature is added in that PR - see `components/youtube_script_injector/common/features.cc`.

Enable YouTube script injector component on Android channels.