### PR TITLE
Disable UseFreedesktopSecretKeyProvider.

### DIFF
--- a/studies/UseFreedesktopSecretKeyProviderKillSwitch.json5
+++ b/studies/UseFreedesktopSecretKeyProviderKillSwitch.json5
@@ -1,0 +1,31 @@
+[
+  {
+    name: 'UseFreedesktopSecretKeyProviderKillSwitch',
+    experiment: [
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+      {
+        name: 'Enabled',
+        probability_weight: 100,
+        feature_association: {
+          disable_feature: [
+            'UseFreedesktopSecretKeyProvider',
+          ],
+        },
+      },
+    ],
+    filter: {
+      min_version: '135.*',
+      channel: [
+        'NIGHTLY',
+        'BETA',
+        'RELEASE',
+      ],
+      platform: [
+        'LINUX',
+      ],
+    },
+  },
+]


### PR DESCRIPTION
The study disables `UseFreedesktopSecretKeyProvider` feature.

This change goes in line with Chromium disabling it recently and uplifting to M135 and M136: https://issues.chromium.org/issues/408004263
https://chromium-review.googlesource.com/c/chromium/src/+/6431417