### PR TITLE
Update Brave Ads studies

### DIFF
--- a/studies/BraveAdsAdEventStudy.json5
+++ b/studies/BraveAdsAdEventStudy.json5
@@ -27,6 +27,7 @@
       },
     ],
     filter: {
+      max_version: '137.1.79.51',
       channel: [
         'NIGHTLY',
         'BETA',

--- a/studies/BraveAdsConversionsStudy.json5
+++ b/studies/BraveAdsConversionsStudy.json5
@@ -23,6 +23,7 @@
       },
     ],
     filter: {
+      max_version: '137.1.79.51',
       channel: [
         'NIGHTLY',
         'BETA',

--- a/studies/BraveAdsExclusionRulesStudy.json5
+++ b/studies/BraveAdsExclusionRulesStudy.json5
@@ -23,6 +23,7 @@
       },
     ],
     filter: {
+      max_version: '137.1.79.51',
       channel: [
         'NIGHTLY',
         'BETA',

--- a/studies/BraveAdsNewTabPageAdsStudy.json5
+++ b/studies/BraveAdsNewTabPageAdsStudy.json5
@@ -23,6 +23,7 @@
       },
     ],
     filter: {
+      max_version: '137.1.79.51',
       channel: [
         'NIGHTLY',
         'BETA',

--- a/studies/BraveAdsSiteVisitStudy.json5
+++ b/studies/BraveAdsSiteVisitStudy.json5
@@ -27,6 +27,7 @@
       },
     ],
     filter: {
+      max_version: '127.1.68.26',
       channel: [
         'NIGHTLY',
         'BETA',

--- a/studies/BraveAdsTextClassificationPageProbabilitiesStudy.json5
+++ b/studies/BraveAdsTextClassificationPageProbabilitiesStudy.json5
@@ -23,6 +23,7 @@
       },
     ],
     filter: {
+      max_version: '137.1.79.51',
       channel: [
         'NIGHTLY',
         'BETA',

--- a/studies/BraveSearchAdStudy.json5
+++ b/studies/BraveSearchAdStudy.json5
@@ -20,6 +20,7 @@
       },
     ],
     filter: {
+      max_version: '136.1.78.81',
       channel: [
         'NIGHTLY',
         'BETA',
@@ -54,6 +55,7 @@
     ],
     filter: {
       min_version: '122.1.65.32',
+      max_version: '136.1.78.81',
       channel: [
         'NIGHTLY',
         'BETA',

--- a/studies/UserActivityStudy.json5
+++ b/studies/UserActivityStudy.json5
@@ -23,10 +23,6 @@
             name: 'threshold',
             value: '0.5',
           },
-          {
-            name: 'idle_time_threshold',
-            value: '5s',
-          },
         ],
       },
       {


### PR DESCRIPTION
This change updates all Brave Ads studies to mirror the browsers default value and a `max_version`, enabling their removal in the future. It also removes the unused `UserActivityStudy` / `idle_time_threshold` field trial parameter.