### PR TITLE
Add study `BraveRewardsPlatformCreatorDetection` for android nightly

### DIFF
--- a/studies/BraveRewardsPlatformCreatorDetectionStudy.json5
+++ b/studies/BraveRewardsPlatformCreatorDetectionStudy.json5
@@ -18,6 +18,7 @@
     ],
     filter: {
       channel: [
+        'BETA',
         'NIGHTLY',
       ],
       platform: [

--- a/studies/BraveRewardsPlatformCreatorDetectionStudy.json5
+++ b/studies/BraveRewardsPlatformCreatorDetectionStudy.json5
@@ -1,0 +1,28 @@
+[
+  {
+    name: 'BraveRewardsPlatformCreatorDetectionStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 100,
+        feature_association: {
+          enable_feature: [
+            'BraveRewardsPlatformCreatorDetection',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      channel: [
+        'NIGHTLY',
+      ],
+      platform: [
+        'ANDROID',
+      ],
+    },
+  },
+]


### PR DESCRIPTION
This PR enables BraveRewardsPlatformCreatorDetection to 100% on Brave Nightly for Android.
I have verified the change using Uphold staging creators listed in [this spreadsheet](https://docs.google.com/spreadsheets/d/1Z-oy0jgOUJdZuFH5sB9a7JT_ZvcKvN1EdI_8hpq6WNU/), with the exception of https://twitch.tv/laurenwags.

We removed Greaselion dependency from Rewards service here : https://github.com/brave/brave-core/pull/25949 and added a new logic for creator detection. 
We tested the feature on desktop first and it's enabled by default on Release channel. 
This PR is enabling the feature on the nightly channel for android to 100% and if all looks good, we would be setting it enabled for other channels. 