### PR TITLE
Add Qwen default model study for >= 1.77.19

### DIFF
--- a/studies/BraveAIChatDefaultModelStudy.json5
+++ b/studies/BraveAIChatDefaultModelStudy.json5
@@ -63,7 +63,7 @@
       },
       {
         name: 'DefaultQwen',
-        probability_weight: 90,
+        probability_weight: 10,
         feature_association: {
           enable_feature: [
             'AIChat',

--- a/studies/BraveAIChatDefaultModelStudy.json5
+++ b/studies/BraveAIChatDefaultModelStudy.json5
@@ -1,6 +1,6 @@
 [
   {
-    name: 'BraveAIChatDefaultModelStudy',
+    name: 'BraveAIChatDefaultModelStudyOlderVersions',
     experiment: [
       {
         name: 'DefaultLlama',
@@ -29,6 +29,56 @@
     ],
     filter: {
       min_version: '122.1.63.161',
+      channel: [
+        'RELEASE',
+        'BETA',
+        'NIGHTLY',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+        'ANDROID',
+        'IOS',
+      ],
+    },
+  },
+  {
+    name: 'BraveAIChatDefaultModelStudy',
+    experiment: [
+      {
+        name: 'DefaultLlama',
+        probability_weight: 90,
+        feature_association: {
+          enable_feature: [
+            'AIChat',
+          ],
+        },
+        param: [
+          {
+            name: 'default_model',
+            value: 'chat-basic',
+          },
+        ],
+      },
+      {
+        name: 'DefaultQwen',
+        probability_weight: 90,
+        feature_association: {
+          enable_feature: [
+            'AIChat',
+          ],
+        },
+        param: [
+          {
+            name: 'default_model',
+            value: 'chat-qwen',
+          },
+        ],
+      },
+    ],
+    filter: {
+      min_version: '133.1.77.19',
       channel: [
         'RELEASE',
         'BETA',

--- a/studies/BraveAIChatDefaultModelStudy.json5
+++ b/studies/BraveAIChatDefaultModelStudy.json5
@@ -29,6 +29,7 @@
     ],
     filter: {
       min_version: '122.1.63.161',
+      max_version: '133.1.77.18',
       channel: [
         'RELEASE',
         'BETA',

--- a/studies/BraveAIChatDefaultModelStudy.json5
+++ b/studies/BraveAIChatDefaultModelStudy.json5
@@ -1,6 +1,6 @@
 [
   {
-    name: 'BraveAIChatDefaultModelStudyOlderVersions',
+    name: 'BraveAIChatDefaultModelStudy_OlderVersions',
     experiment: [
       {
         name: 'DefaultLlama',
@@ -44,7 +44,7 @@
     },
   },
   {
-    name: 'BraveAIChatDefaultModelStudy',
+    name: 'BraveAIChatDefaultModelStudy_Qwen',
     experiment: [
       {
         name: 'DefaultLlama',


### PR DESCRIPTION
  * Rename the existing default model study to `BraveAIChatDefaultModelStudyOlderVersions` to apply only to versions before 1.77.19.
  * Introduce a new `BraveAIChatDefaultModelStudy` targeting Brave versions 1.77.19 and newer across all channels and platforms. This study adds 'chat-qwen' as a possible default model alongside 'chat-basic'.