### PR TITLE
Add Android and Desktop onboarding study

### DIFF
--- a/studies/BraveDayZeroStudy.json5
+++ b/studies/BraveDayZeroStudy.json5
@@ -1,0 +1,81 @@
+[
+  {
+    name: 'BraveDayZeroStudy_Android',
+    experiment: [
+      {
+        name: 'EnabledA',
+        probability_weight: 3,
+        feature_association: {
+          enable_feature: [
+            'BraveDayZeroExperiment',
+          ],
+        },
+        param: [
+          {
+            name: 'variant',
+            value: 'a',
+          },
+        ],
+      },
+      {
+        name: 'EnabledB',
+        probability_weight: 3,
+        feature_association: {
+          enable_feature: [
+            'BraveDayZeroExperiment',
+          ],
+        },
+        param: [
+          {
+            name: 'variant',
+            value: 'b',
+          },
+        ],
+      },
+      {
+        name: 'EnabledC',
+        probability_weight: 3,
+        feature_association: {
+          enable_feature: [
+            'BraveDayZeroExperiment',
+          ],
+        },
+        param: [
+          {
+            name: 'variant',
+            value: 'c',
+          },
+        ],
+      },
+      {
+        name: 'EnabledD',
+        probability_weight: 3,
+        feature_association: {
+          enable_feature: [
+            'BraveDayZeroExperiment',
+          ],
+        },
+        param: [
+          {
+            name: 'variant',
+            value: 'd',
+          },
+        ],
+      },
+      {
+        name: 'Default',
+        probability_weight: 88,
+      },
+    ],
+    filter: {
+      channel: [
+        'RELEASE',
+        'BETA',
+        'NIGHTLY',
+      ],
+      platform: [
+        'ANDROID',
+      ],
+    },
+  },
+]

--- a/studies/BraveDayZeroStudy.json5
+++ b/studies/BraveDayZeroStudy.json5
@@ -68,7 +68,7 @@
       },
     ],
     filter: {
-      min_version: '136.0.7103.48',
+      min_version: '136.1.78.94',
       channel: [
         'RELEASE',
         'BETA',
@@ -76,6 +76,56 @@
       ],
       platform: [
         'ANDROID',
+      ],
+    },
+  },
+  {
+    name: 'BraveDayZeroStudy_Desktop',
+    experiment: [
+      {
+        name: 'EnabledC',
+        probability_weight: 18,
+        feature_association: {
+          enable_feature: [
+            'BraveDayZeroExperiment',
+          ],
+        },
+        param: [
+          {
+            name: 'variant',
+            value: 'c',
+          },
+        ],
+      },
+      {
+        name: 'EnabledD',
+        probability_weight: 18,
+        feature_association: {
+          enable_feature: [
+            'BraveDayZeroExperiment',
+          ],
+        },
+        param: [
+          {
+            name: 'variant',
+            value: 'd',
+          },
+        ],
+      },
+      {
+        name: 'Default',
+        probability_weight: 64,
+      },
+    ],
+    filter: {
+      min_version: '136.1.78.94',
+      channel: [
+        'RELEASE',
+        'BETA',
+        'NIGHTLY',
+      ],
+      platform: [
+        'WINDOWS',
       ],
     },
   },

--- a/studies/BraveDayZeroStudy.json5
+++ b/studies/BraveDayZeroStudy.json5
@@ -68,6 +68,7 @@
       },
     ],
     filter: {
+      min_version: '136.0.7103.48',
       channel: [
         'RELEASE',
         'BETA',


### PR DESCRIPTION
In this study, we are assigning 3% weight to each of the variants A, B, C, and D, with the remaining 88% allocated to the default group for android onboarding changes. 

For more details : https://docs.google.com/document/d/1_2-okYXJbFIsoUtsCWwnF46sBuPBOR-bAfetArLrWwU/edit?tab=t.0#heading=h.e26mh6aq4tpw