### PR TITLE
Bump PartitionVisitedLinkDatabaseWithSelfLinks to 25% on Release

### DIFF
--- a/studies/PartitionVisitedLinkDatabaseWithSelfLinks.json5
+++ b/studies/PartitionVisitedLinkDatabaseWithSelfLinks.json5
@@ -31,7 +31,7 @@
     },
   },
   {
-    name: 'PartitionVisitedLinkDatabaseWithSelfLinksRelease',
+    name: 'PartitionVisitedLinkDatabaseWithSelfLinks_Release',
     experiment: [
       {
         name: 'Enabled',

--- a/studies/PartitionVisitedLinkDatabaseWithSelfLinks.json5
+++ b/studies/PartitionVisitedLinkDatabaseWithSelfLinks.json5
@@ -30,4 +30,34 @@
       ],
     },
   },
+  {
+    name: 'PartitionVisitedLinkDatabaseWithSelfLinksRelease',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 25,
+        feature_association: {
+          enable_feature: [
+            'PartitionVisitedLinkDatabaseWithSelfLinks',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 75,
+      },
+    ],
+    filter: {
+      min_version: '134.1.77.83',
+      channel: [
+        'RELEASE',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+        'ANDROID',
+      ],
+    },
+  },
 ]


### PR DESCRIPTION
Fix https://github.com/brave/brave-variations/issues/1377

Chrome has rolled this out to 100% on Release.