### PR TITLE
Disable RasterInducingScroll: RELEASE 10%

### DIFF
--- a/studies/RasterInducingScrollKillSwitch.json5
+++ b/studies/RasterInducingScrollKillSwitch.json5
@@ -1,0 +1,57 @@
+[
+  {
+    name: 'RasterInducingScrollKillSwitch',
+    experiment: [
+      {
+        name: 'Disabled_EmergencyKillSwitch',
+        probability_weight: 100,
+        feature_association: {
+          disable_feature: [
+            'RasterInducingScroll',
+          ],
+        },
+      },
+    ],
+    filter: {
+      min_version: '131.*',
+      max_version: '137.*',
+      channel: [
+        'BETA',
+        'NIGHTLY',
+      ],
+      platform: [
+        'WINDOWS',
+        'LINUX',
+      ],
+    },
+  },
+  {
+    name: 'RasterInducingScrollKillSwitch',
+    experiment: [
+      {
+        name: 'Disabled_EmergencyKillSwitch',
+        probability_weight: 10,
+        feature_association: {
+          disable_feature: [
+            'RasterInducingScroll',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 90,
+      },
+    ],
+    filter: {
+      min_version: '131.*',
+      max_version: '137.*',
+      channel: [
+        'RELEASE',
+      ],
+      platform: [
+        'WINDOWS',
+        'LINUX',
+      ],
+    },
+  },
+]


### PR DESCRIPTION
For https://github.com/brave/brave-variations/issues/1380
NIGHLY/BETA: 100%
RELEASE: 10%

Steps to reproduce is in the issue.
Slack thread: https://bravesoftware.slack.com/archives/C05S50MFHPE/p1746015204577549