### PR TITLE
BraveAdsNewTabPageAdsShouldSupportConfirmationsForNonRewardsStudy

### DIFF
--- a/studies/BraveAdsNewTabPageAdsStudy.json5
+++ b/studies/BraveAdsNewTabPageAdsStudy.json5
@@ -38,4 +38,42 @@
       ],
     },
   },
+  {
+    name: 'BraveAdsNewTabPageAdsStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 100,
+        feature_association: {
+          enable_feature: [
+            'NewTabPageAds',
+          ],
+        },
+        param: [
+          {
+            name: 'should_support_confirmations_for_non_rewards',
+            value: 'true',
+          },
+        ],
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      min_version: '137.1.80.31',
+      channel: [
+        'NIGHTLY',
+        'BETA',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+        'ANDROID',
+        'IOS',
+      ],
+    },
+  },
 ]


### PR DESCRIPTION
Rolling out the feature to Nightly and Beta to support confirmations for non-Rewards users. For the next few days, `campaigns.json` should continue to use `"metrics": "p3a"` to confirm that confirmations aren’t being sent (monitored by https://metabase.bsg.brave.com/question/3589-ntt-frequency-capping-non-rewards-https-github-com-brave-brave-browser-issues-45817). After that, we can test metrics that include confirmations for a given house campaign.