### PR TITLE
PartitionVisitedLinkDatabaseWithSelfLinks to 100% on Release

### DIFF
--- a/studies/PartitionVisitedLinkDatabaseWithSelfLinks.json5
+++ b/studies/PartitionVisitedLinkDatabaseWithSelfLinks.json5
@@ -35,7 +35,7 @@
     experiment: [
       {
         name: 'Enabled',
-        probability_weight: 25,
+        probability_weight: 100,
         feature_association: {
           enable_feature: [
             'PartitionVisitedLinkDatabaseWithSelfLinks',
@@ -44,7 +44,7 @@
       },
       {
         name: 'Default',
-        probability_weight: 75,
+        probability_weight: 0,
       },
     ],
     filter: {


### PR DESCRIPTION
We've had a fairly slow rollout of this. Given that Chrome has it fully enabled, and we've also rolled it out to 100% on Nightly and Beta followed by 25% on Release, seems very safe to fully roll out.

Fix https://github.com/brave/brave-variations/issues/1392