### PR TITLE
Enable Brave UA on iOS release channel

### DIFF
--- a/studies/BraveUAStudy.json5
+++ b/studies/BraveUAStudy.json5
@@ -1,0 +1,28 @@
+[
+  {
+    name: 'BraveUAStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 100,
+        feature_association: {
+          enable_feature: [
+            'UseBraveUserAgent',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      channel: [
+        'RELEASE',
+      ],
+      platform: [
+        'IOS',
+      ],
+    },
+  },
+]


### PR DESCRIPTION
Temporary measure while we work with Cloudflare to support the user agent used in desktop mode