### PR TITLE
Disables TabStripLayoutOptimization feature flag on Android

### DIFF
--- a/studies/TabStripLayoutOptimization.json5
+++ b/studies/TabStripLayoutOptimization.json5
@@ -1,0 +1,28 @@
+[
+  {
+    name: 'TabStripLayoutOptimization',
+    experiment: [
+      {
+        name: 'Disabled_TabStripLayoutOptimization',
+        probability_weight: 100,
+        feature_association: {
+          disable_feature: [
+            'TabStripLayoutOptimization',
+          ],
+        },
+      },
+    ],
+    filter: {
+      min_version: '135.*',
+      max_version: '136.*',
+      channel: [
+        'NIGHTLY',
+        'BETA',
+        'RELEASE',
+      ],
+      platform: [
+        'ANDROID',
+      ],
+    },
+  },
+]


### PR DESCRIPTION
Resolves https://github.com/brave/brave-variations/issues/1402
Just make sure that chrome://flags/#tab-strip-layout-optimization is disabled after the study applied.