### PR TITLE
Enable UseChromiumWebViews on Beta iOS

### DIFF
--- a/studies/iOSChromiumWebViewsStudy.json5
+++ b/studies/iOSChromiumWebViewsStudy.json5
@@ -17,7 +17,9 @@
       },
     ],
     filter: {
+      min_version: '137.1.80.103',
       channel: [
+        'BETA',
         'NIGHTLY',
       ],
       platform: [


### PR DESCRIPTION
Enables the `UseChromiumWebViews` feature flag on the beta channel as well as nightly