### PR TITLE
[DO NOT MERGE] Disable ExtensionsManifestV2 feature on Nightly.

### DIFF
--- a/studies/ExtensionsManifestV2Study.json5
+++ b/studies/ExtensionsManifestV2Study.json5
@@ -18,9 +18,39 @@
     ],
     filter: {
       min_version: '125.1.68.25',
+      max_version: '137.1.81.71',
       channel: [
         'NIGHTLY',
         'BETA',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+      ],
+    },
+  },
+  {
+    name: 'ExtensionsManifestV2Study_NextStepPreparation',
+    experiment: [
+      {
+        name: 'Disabled',
+        probability_weight: 100,
+        feature_association: {
+          disable_feature: [
+            'ExtensionsManifestV2',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      min_version: '137.1.81.72',
+      channel: [
+        'NIGHTLY',
       ],
       platform: [
         'WINDOWS',


### PR DESCRIPTION
Resolves https://github.com/brave/brave-variations/issues/1421

When the feature is disabled, the user can't interact with the `brave://settings/extensions/v2` page.