### PR TITLE
Roll non-rewards NTT confirmations to 50% release

### DIFF
--- a/studies/BraveAdsNewTabPageAdsStudy.json5
+++ b/studies/BraveAdsNewTabPageAdsStudy.json5
@@ -81,7 +81,7 @@
     experiment: [
       {
         name: 'Enabled',
-        probability_weight: 25,
+        probability_weight: 50,
         feature_association: {
           enable_feature: [
             'NewTabPageAds',
@@ -96,7 +96,7 @@
       },
       {
         name: 'Default',
-        probability_weight: 75,
+        probability_weight: 50,
       },
     ],
     filter: {


### PR DESCRIPTION
Roll out `BraveAdsNewTabPageAdsStudy` with `NewTabPageAds/should_support_confirmations_for_non_rewards` feature parameter to 50% in Release channel to support New Tab Takeover confirmations for non-Rewards users.

The current PR should be merged in 1 week after 25% Release channel roll-out is merged in: https://github.com/brave/brave-variations/pull/1424 (merged on June 24, 2025).