### PR TITLE
BraveNTPBrandedWallpaperSurveyPanelistStudy

### DIFF
--- a/studies/BraveNTPBrandedWallpaperSurveyPanelistStudy.json5
+++ b/studies/BraveNTPBrandedWallpaperSurveyPanelistStudy.json5
@@ -1,0 +1,34 @@
+[
+  {
+    name: 'BraveNTPBrandedWallpaperSurveyPanelistStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 100,
+        feature_association: {
+          enable_feature: [
+            'BraveNTPBrandedWallpaperSurveyPanelist',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      min_version: '138.1.81.80',
+      channel: [
+        'NIGHTLY',
+        'BETA',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+        'ANDROID',
+        'IOS',
+      ],
+    },
+  },
+]


### PR DESCRIPTION
Roll out survey panelists feature to nightly and beta. See https://github.com/brave/brave-browser/issues/45990.