### PR TITLE
Roll non-rewards NTT confirmations to 100% release

### DIFF
--- a/studies/BraveAdsNewTabPageAdsStudy.json5
+++ b/studies/BraveAdsNewTabPageAdsStudy.json5
@@ -85,7 +85,7 @@
     experiment: [
       {
         name: 'Enabled',
-        probability_weight: 50,
+        probability_weight: 100,
         feature_association: {
           enable_feature: [
             'NewTabPageAds',
@@ -100,7 +100,7 @@
       },
       {
         name: 'Default',
-        probability_weight: 50,
+        probability_weight: 0,
       },
     ],
     filter: {


### PR DESCRIPTION
Roll out `BraveAdsNewTabPageAdsStudy` with
`NewTabPageAds/should_support_confirmations_for_non_rewards` feature parameter to 100% in Release channel to support New Tab Takeover confirmations for non-Rewards users.

`BraveAdsNewTabPageAdsStudy` was rolled-out for 50% Release channel via: https://github.com/brave/brave-variations/pull/1427