### PR TITLE
Enable ModernTabTrayEnabled on iOS Nightly

### DIFF
--- a/studies/NewiOSTabTrayUIStudy.json5
+++ b/studies/NewiOSTabTrayUIStudy.json5
@@ -1,0 +1,28 @@
+[
+  {
+    name: 'NewiOSTabTrayUIStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 100,
+        feature_association: {
+          enable_feature: [
+            'ModernTabTrayEnabled',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      channel: [
+        'NIGHTLY',
+      ],
+      platform: [
+        'IOS',
+      ],
+    },
+  },
+]


### PR DESCRIPTION
This enables the new tab tray UI on nightly builds, no min version required as feature was introduced with the flag.

PR: https://github.com/brave/brave-core/pull/29943