### PR TITLE
Enable BraveNewTabPageRefreshEnabled on Desktop Nightly

### DIFF
--- a/studies/BraveNewTabPageRefreshStudy.json5
+++ b/studies/BraveNewTabPageRefreshStudy.json5
@@ -1,0 +1,31 @@
+[
+  {
+    name: 'BraveNewTabPageRefreshStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 100,
+        feature_association: {
+          enable_feature: [
+            'BraveNewTabPageRefreshEnabled',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      min_version: '138.1.82.90',
+      channel: [
+        'NIGHTLY',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+      ],
+    },
+  },
+]


### PR DESCRIPTION
Resolves #1442 

Enables the new version of the desktop new tab page on Nightly.