### PR TITLE
Disable NTP Super Referral wallpapers

### DIFF
--- a/studies/BraveNTPSuperReferralWallpaperNameDisableStudy.json5
+++ b/studies/BraveNTPSuperReferralWallpaperNameDisableStudy.json5
@@ -28,8 +28,6 @@
         'WINDOWS',
         'MAC',
         'LINUX',
-        'ANDROID',
-        'IOS',
       ],
     },
   },


### PR DESCRIPTION
PR fixes https://github.com/brave/brave-browser/issues/47719 bug where `NTP Super Referral mapping table` component install failure blocks NTT display for new browser installs.

PR sets min version to `134.1.76.0` because `NTP Super Referral mapping table` component was removed in https://github.com/brave/devops/pull/13322 on March 12. The brave stable version on March 12 was `1.76`.

PR sets max version to `138.1.81.88` because the `BraveNTPSuperReferralWallpaperName` feature was disabled by default in https://github.com/brave/brave-core/pull/29560, which is merged to `138.1.81.88`.


## Test plan

### Test case 1 (fresh install)
* Download browser from brave.com
* Start browser with griffin seed applied
* Wait until `NTP Sponsored Images` component is downloaded
* Open several NTPs
   EXPECTATION: NTTs are shown

### Test case 2 (update)
* Download browser from brave.com
* Start browser without griffin seed applied
* Wait until `NTP Sponsored Images` component is downloaded
* Open several NTPs
* Close the browser
* Start browser with griffin seed applied
* Open several NTPs
   EXPECTATION: NTTs are shown
