### PR TITLE
Disable NTP Super Referral wallpapers on Android

### DIFF
--- a/studies/BraveNTPSuperReferralWallpaperNameDisableStudy.json5
+++ b/studies/BraveNTPSuperReferralWallpaperNameDisableStudy.json5
@@ -28,6 +28,7 @@
         'WINDOWS',
         'MAC',
         'LINUX',
+        'ANDROID',
       ],
     },
   },


### PR DESCRIPTION
PR fixes https://github.com/brave/brave-browser/issues/47849 bug where `NTP Super Referral mapping table` component install failure blocks NTT display for new browser promo installs on Android.

Min version is `134.1.76.0` because `NTP Super Referral mapping table` component was removed in https://github.com/brave/devops/pull/13322 on March 12. The brave stable version on March 12 was `1.76`.

Max version is `138.1.81.88` because the `BraveNTPSuperReferralWallpaperName` feature was disabled by default in https://github.com/brave/brave-core/pull/29560, which is merged to `138.1.81.88`.

## Test plan

### Test case 1 (fresh install)
* Promo install browser on Android
* Start browser with griffin seed applied
* Open several NTPs
   EXPECTATION: NTTs are shown

### Test case 2 (update)
* Promo install browser on Android
* Start browser without griffin seed applied
* Open several NTPs
  EXPECTATION: NTTs are not shown
* Close the browser
* Start browser with griffin seed applied
* Open several NTPs
   EXPECTATION: NTTs are shown
