### PR TITLE
Roll non-rewards NTT confirmations to 15% release

### DIFF
--- a/studies/BraveAdsNewTabPageAdsStudy.json5
+++ b/studies/BraveAdsNewTabPageAdsStudy.json5
@@ -80,4 +80,73 @@
       ],
     },
   },
+  {
+    name: 'BraveAdsNewTabPageAdsStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 15,
+        feature_association: {
+          enable_feature: [
+            'NewTabPageAds',
+          ],
+        },
+        param: [
+          {
+            name: 'should_support_confirmations_for_non_rewards',
+            value: 'true',
+          },
+        ],
+      },
+      {
+        name: 'Default',
+        probability_weight: 85,
+      },
+    ],
+    filter: {
+      min_version: '138.1.80.122',
+      channel: [
+        'RELEASE',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+        'ANDROID',
+      ],
+    },
+  },
+  {
+    name: 'BraveAdsNewTabPageAdsStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 15,
+        feature_association: {
+          enable_feature: [
+            'NewTabPageAds',
+          ],
+        },
+        param: [
+          {
+            name: 'should_support_confirmations_for_non_rewards',
+            value: 'true',
+          },
+        ],
+      },
+      {
+        name: 'Default',
+        probability_weight: 85,
+      },
+    ],
+    filter: {
+      min_version: '138.1.80.121',
+      channel: [
+        'RELEASE',
+      ],
+      platform: [
+        'IOS',
+      ],
+    },
+  },
 ]


### PR DESCRIPTION
Roll out `BraveAdsNewTabPageAdsStudy` with `NewTabPageAds/should_support_confirmations_for_non_rewards` feature parameter to 15% in Release channel to support New Tab Takeover confirmations for non-Rewards users.

The study has min_version: '138.1.80.122' for **Desktop and Android**, which is needed to include NTT infobar crash fix from https://github.com/brave/brave-core/pull/30002.

The study has min_version: '138.1.80.121' for **iOS** because it is the current iOS Release version and the NTT infobar crash above doesn't affect iOS.

This is the reland of `BraveAdsNewTabPageAdsStudy` roll out which was reverted due to Desktop crash via https://github.com/brave/brave-variations/pull/1439