### PR TITLE
Roll non-rewards NTT confirmations to 50% release

### DIFF
--- a/studies/BraveAdsNewTabPageAdsStudy.json5
+++ b/studies/BraveAdsNewTabPageAdsStudy.json5
@@ -85,7 +85,7 @@
     experiment: [
       {
         name: 'Enabled',
-        probability_weight: 25,
+        probability_weight: 50,
         feature_association: {
           enable_feature: [
             'NewTabPageAds',
@@ -100,7 +100,7 @@
       },
       {
         name: 'Default',
-        probability_weight: 75,
+        probability_weight: 50,
       },
     ],
     filter: {
@@ -121,7 +121,7 @@
     experiment: [
       {
         name: 'Enabled',
-        probability_weight: 25,
+        probability_weight: 50,
         feature_association: {
           enable_feature: [
             'NewTabPageAds',
@@ -136,7 +136,7 @@
       },
       {
         name: 'Default',
-        probability_weight: 75,
+        probability_weight: 50,
       },
     ],
     filter: {


### PR DESCRIPTION
Roll out `BraveAdsNewTabPageAdsStudy` with `NewTabPageAds/should_support_confirmations_for_non_rewards` feature parameter to 50% in Release channel to support New Tab Takeover confirmations for non-Rewards users.

The study has min_version: '138.1.80.122' for **Desktop and Android**, which is needed to include NTT infobar crash fix from https://github.com/brave/brave-core/pull/30002.

The study has min_version: '138.1.80.121' for **iOS** because it is the current iOS Release version and the NTT infobar crash above doesn't affect iOS.

Previously the `BraveAdsNewTabPageAdsStudy` was rolled out to 25% via https://github.com/brave/brave-variations/pull/1452.