### PR TITLE
BraveNTPBrandedWallpaperSurveyPanelistStudy

### DIFF
--- a/studies/BraveNTPBrandedWallpaperSurveyPanelistStudy.json5
+++ b/studies/BraveNTPBrandedWallpaperSurveyPanelistStudy.json5
@@ -31,4 +31,35 @@
       ],
     },
   },
+  {
+    name: 'BraveNTPBrandedWallpaperSurveyPanelistStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 25,
+        feature_association: {
+          enable_feature: [
+            'BraveNTPBrandedWallpaperSurveyPanelist',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 75,
+      },
+    ],
+    filter: {
+      min_version: '138.1.81.80',
+      channel: [
+        'RELEASE',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+        'ANDROID',
+        'IOS',
+      ],
+    },
+  },
 ]


### PR DESCRIPTION
Roll out survey panelists to release at 100%. See https://github.com/brave/brave-browser/issues/45990.