### PR TITLE
Fixed config import.

### DIFF
--- a/src/core/blocklists.ts
+++ b/src/core/blocklists.ts
@@ -2,7 +2,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
-import * as config from '../config';
+import config from '../config';
 
 class Blocklist {
   private readonly regexps: RegExp[] = [];

--- a/src/core/summary.ts
+++ b/src/core/summary.ts
@@ -12,7 +12,7 @@ import {
   type ProcessedStudy,
 } from './study_processor';
 
-import * as config from '../config';
+import config from '../config';
 import { VariationsSeed } from '../proto/generated/variations_seed';
 import * as url_utils from './url_utils';
 


### PR DESCRIPTION
```
#     for (const line of patterns) {
#                        ^
# TypeError: patterns is not iterable
#     at new Blocklist (/home/runner/work/brave-variations/brave-variations/src/core/blocklists.ts:11:24)
#     at <anonymous> (/home/runner/work/brave-variations/brave-variations/src/core/blocklists.ts:27:25)
#     at ModuleJob.run (node:internal/modules/esm/module_job:343:25)
#     at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:647:26)
#     at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)
```
This error occurs on node 22.18+