### PR TITLE
Disable ContextMenuEmptySpace to follow upstream

### DIFF
--- a/studies/EmptySpaceContextMenuPhoneKillSwitch.json5
+++ b/studies/EmptySpaceContextMenuPhoneKillSwitch.json5
@@ -1,0 +1,32 @@
+[
+  {
+    name: 'EmptySpaceContextMenuPhoneKillSwitch',
+    consistency: 'PERMANENT',
+    experiment: [
+      {
+        name: 'Disabled_ContextMenuEmptySpace',
+        probability_weight: 100,
+        feature_association: {
+          disable_feature: [
+            'ContextMenuEmptySpace',
+          ],
+        },
+      },
+    ],
+    filter: {
+      min_version: '139.*',
+      max_version: '140.*',
+      channel: [
+        'NIGHTLY',
+        'BETA',
+        'RELEASE',
+      ],
+      platform: [
+        'ANDROID',
+      ],
+      form_factor: [
+        'PHONE',
+      ],
+    },
+  },
+]


### PR DESCRIPTION
There are issues with YT 2x speed option on certain devices, Samsung specifically. Chrome disabled the flag in 139.0.7229.0 till 140.0.7326.0. We need to follow.
Resolves: https://github.com/brave/brave-variations/issues/1472

The flag is brave://flags/#enable-empty-space-context-menu-clank