### PR TITLE
BraveNTPBrandedWallpaperStudy

### DIFF
--- a/studies/BraveNTPBrandedWallpaperStudy.json5
+++ b/studies/BraveNTPBrandedWallpaperStudy.json5
@@ -1,0 +1,44 @@
+[
+  {
+    name: 'BraveNTPBrandedWallpaperStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 100,
+        feature_association: {
+          enable_feature: [
+            'BraveNTPBrandedWallpaper',
+          ],
+        },
+        param: [
+          {
+            name: 'initial_count_to_branded_wallpaper',
+            value: '1',
+          },
+          {
+            name: 'count_to_branded_wallpaper',
+            value: '2',
+          },
+        ],
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      channel: [
+        'NIGHTLY',
+        'BETA',
+        'RELEASE',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+        'ANDROID',
+        'IOS',
+      ],
+    },
+  },
+]

--- a/studies/BraveNTPBrandedWallpaperStudy.json5
+++ b/studies/BraveNTPBrandedWallpaperStudy.json5
@@ -17,7 +17,7 @@
           },
           {
             name: 'count_to_branded_wallpaper',
-            value: '2',
+            value: '3',
           },
         ],
       },


### PR DESCRIPTION
Changes NTT so it opens on the 1st tab instead of the 2nd at browser launch, and then on every 2nd tab instead of every 3rd tab thereafter. https://github.com/brave/brave-variations/issues/1485