### PR TITLE
ClipElementVisibleBoundsInLocalRootKillSwitch 25% Stable

### DIFF
--- a/studies/ClipElementVisibleBoundsInLocalRootKillSwitch.json5
+++ b/studies/ClipElementVisibleBoundsInLocalRootKillSwitch.json5
@@ -34,7 +34,7 @@
     experiment: [
       {
         name: 'Disabled_ClipElementVisibleBoundsInLocalRootKillSwitch',
-        probability_weight: 5,
+        probability_weight: 25,
         feature_association: {
           disable_feature: [
             'ClipElementVisibleBoundsInLocalRoot',
@@ -43,7 +43,7 @@
       },
       {
         name: 'Default',
-        probability_weight: 95,
+        probability_weight: 75,
       },
     ],
     filter: {


### PR DESCRIPTION
For https://github.com/brave/brave-variations/issues/1488
Stable 25%

The previous PR: https://github.com/brave/brave-variations/pull/1487

The PR mirrors the upstream changes to disable broken ClipElementVisibleBoundsInLocalRoot.

