### PR TITLE
Fix google auth issues with enabled BTM service.

### DIFF
--- a/studies/BTMGoogleAuthWorkaround.json5
+++ b/studies/BTMGoogleAuthWorkaround.json5
@@ -1,0 +1,38 @@
+[
+  {
+    name: 'BTMGoogleAuthWorkaround',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 100,
+        feature_association: {
+          enable_feature: [
+            'DIPS',
+          ],
+        },
+        param: [
+          {
+            name: 'triggering_action',
+            value: 'none',
+          },
+        ],
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      min_version: '140.*',
+      channel: [
+        'NIGHTLY',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+        'ANDROID',
+      ],
+    },
+  },
+]


### PR DESCRIPTION
## This change disables Bounce Tracking Mitigation (BTM, previously DIPS), which incorrectly triggers Device-Bound Session termination (currently in use by default by Google since cr140 on Windows).

The issue is related to how we partition 3p cookies in Brave and how `BtmServiceImpl` service interop in an unexpected way with `BoundSessionCookieRefreshServiceImpl`:

1. We alter cookie allowance mechanism which prevents this value to be set to `true`:
```
redirect->has_3pc_exception =
        browser_client->IsFullCookieAccessAllowed(browser_context, web_contents,
                                                  redirect->redirector.url,
                                                  initial_url_key, overrides) ||
        browser_client->IsFullCookieAccessAllowed(browser_context, web_contents,
                                                  redirect->redirector.url,
                                                  final_url_key, overrides);
```
2. This in turn allows `BtmServiceImpl` to track cookie bouncing for `google.com` and later schedule the cleanup.
3. The cleanup happens after 2 hours. See `kBtmGracePeriod` + `kBtmTimerDelay`.
4. The cleanup consists of two separate cookie cleanup calls. The first one is normal, but the second one is this:
```
    // This filter will match cookies partitioned under tracking domains.
    std::unique_ptr<BrowsingDataFilterBuilder> partitioned_cookie_filter =
        BrowsingDataFilterBuilder::Create(
            BrowsingDataFilterBuilder::Mode::kPreserve);
    partitioned_cookie_filter->SetCookiePartitionKeyCollection(
        CookiePartitionKeyCollectionForSites(sites_to_clear));
    partitioned_cookie_filter->SetPartitionedCookiesOnly(true);
    // We don't add any domains to this filter, so with mode=kPreserve it will
    // delete everything partitioned under the sites.
```

This `kPreserve` cleanup is meant to only remove partitioned third party cookies. However this event is incorrectly handled as "first party cookie cleanup" in `BoundSessionCookieRefreshServiceImpl::OnStorageKeyDataCleared`, which leads to session termination for no reason.

## Testing

0. Use testing instruction below to start the browser with variations from this PR.
1. Make sure your PC has TPM enabled. Authenticate to Google.
2. Make sure `brave://histograms/Signin.BoundSessionCredentials` shows `0  --O` for `Signin.BoundSessionCredentials.StorageWriteError` histogram. This means [Device Bound Session Credentials](https://developer.chrome.com/docs/web-platform/device-bound-session-credentials) is in use) and in general you should see other histograms there (~15 in total). <img width="1350" height="112" alt="image" src="https://github.com/user-attachments/assets/2049a172-cf18-41e2-b1ed-44b75cc75a6d" />
3. Wait 2+ hours
4. Ensure you're not logged out and there's no `Signin.BoundSessionCredentials.SessionTerminationTrigger` appeared with value `1`.

Related https://github.com/brave/brave-browser/issues/49300