### PR TITLE
Enable BTM Google auth workaround on beta channel.

### DIFF
--- a/studies/BTMGoogleAuthWorkaround.json5
+++ b/studies/BTMGoogleAuthWorkaround.json5
@@ -26,6 +26,7 @@
       min_version: '140.*',
       channel: [
         'NIGHTLY',
+        'BETA',
       ],
       platform: [
         'WINDOWS',


### PR DESCRIPTION
Roll the fix from [1] to beta channel.

1. https://github.com/brave/brave-variations/pull/1504