### PR TITLE
Disable all built-in AI APIs and related features

### DIFF
--- a/studies/BuiltInAIAPIsDisabledStudy.json5
+++ b/studies/BuiltInAIAPIsDisabledStudy.json5
@@ -1,0 +1,44 @@
+[
+  {
+    name: 'BuiltInAIAPIsDisabledStudy',
+    experiment: [
+      {
+        name: 'Disabled',
+        probability_weight: 100,
+        feature_association: {
+          disable_feature: [
+            'BuiltInAIAPI',
+            'AIPromptAPI',
+            'AIPromptAPIMultimodalInput',
+            'AIRewriterAPI',
+            'AISummarizationAPI',
+            'AIWriterAPI',
+            'LanguageDetectionAPI',
+            'TranslationAPI',
+            'AIProofreadingAPI',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      min_version: '130.1.70.0',
+      channel: [
+        'RELEASE',
+        'BETA',
+        'DEV',
+        'NIGHTLY',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+        'ANDROID',
+        'IOS',
+      ],
+    },
+  },
+]

--- a/studies/BuiltInAIAPIsDisabledStudy.json5
+++ b/studies/BuiltInAIAPIsDisabledStudy.json5
@@ -1,6 +1,44 @@
 [
   {
-    name: 'BuiltInAIAPIsDisabledStudy',
+    name: 'BuiltInAIAPIsDisabledStudy_Release',
+    experiment: [
+      {
+        name: 'Disabled',
+        probability_weight: 5,
+        feature_association: {
+          disable_feature: [
+            'BuiltInAIAPI',
+            'AIPromptAPI',
+            'AIPromptAPIMultimodalInput',
+            'AIRewriterAPI',
+            'AISummarizationAPI',
+            'AIWriterAPI',
+            'LanguageDetectionAPI',
+            'TranslationAPI',
+            'AIProofreadingAPI',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 95,
+      },
+    ],
+    filter: {
+      channel: [
+        'RELEASE',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+        'ANDROID',
+        'IOS',
+      ],
+    },
+  },
+  {
+    name: 'BuiltInAIAPIsDisabledStudy_Other',
     experiment: [
       {
         name: 'Disabled',
@@ -25,9 +63,7 @@
       },
     ],
     filter: {
-      min_version: '130.1.70.0',
       channel: [
-        'RELEASE',
         'BETA',
         'DEV',
         'NIGHTLY',

--- a/studies/BuiltInAIAPIsDisabledStudy.json5
+++ b/studies/BuiltInAIAPIsDisabledStudy.json5
@@ -65,7 +65,6 @@
     filter: {
       channel: [
         'BETA',
-        'DEV',
         'NIGHTLY',
       ],
       platform: [


### PR DESCRIPTION
Add BuiltInAIAPIsDisabledStudy to disable all AI API features that use closed source components:
- BuiltInAIAPI
- AIPromptAPI
- AIPromptAPIMultimodalInput
- AIRewriterAPI
- AISummarizationAPI
- AIWriterAPI
- LanguageDetectionAPI
- TranslationAPI
- AIProofreadingAPI

Relates to https://github.com/brave/brave-browser/issues/49502