### PR TITLE
Adjusts max_version of AndroidTooltipsKillSwitch to 141

### DIFF
--- a/studies/AndroidTooltipsKillSwitch.json5
+++ b/studies/AndroidTooltipsKillSwitch.json5
@@ -15,7 +15,7 @@
     ],
     filter: {
       min_version: '140.*',
-      max_version: '142.*',
+      max_version: '141.*',
       channel: [
         'NIGHTLY',
         'BETA',


### PR DESCRIPTION
Resolves: https://github.com/brave/brave-variations/issues/1513