### PR TITLE
Revert "Enable ModernTabTrayEnabled on iOS Release"

### DIFF
--- a/studies/NewiOSTabTrayUIStudy.json5
+++ b/studies/NewiOSTabTrayUIStudy.json5
@@ -18,7 +18,6 @@
     ],
     filter: {
       channel: [
-        'RELEASE',
         'BETA',
         'NIGHTLY',
       ],


### PR DESCRIPTION
This reverts commit 334765b91c6f0fb693610faaedcce33c37fa6942.