### PR TITLE
Enable UpgradeWhenIdle on Nightly Mac

### DIFF
--- a/studies/UpgradeWhenIdleStudy.json5
+++ b/studies/UpgradeWhenIdleStudy.json5
@@ -1,0 +1,25 @@
+[
+  {
+    name: 'UpgradeWhenIdleStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 100,
+        feature_association: {
+          enable_feature: [
+            'UpgradeWhenIdle',
+          ],
+        },
+      },
+    ],
+    filter: {
+      min_version: '140.1.84.84',
+      channel: [
+        'NIGHTLY',
+      ],
+      platform: [
+        'MAC',
+      ],
+    },
+  },
+]


### PR DESCRIPTION
The feature only applies to Mac.

Resolves https://github.com/brave/brave-browser/issues/45426.