### PR TITLE
Disable LocalNetworkAccessChecks: Nightly/Beta 100%, Release 5%

### DIFF
--- a/studies/LocalNetworkAccessChecksKillSwitch.json5
+++ b/studies/LocalNetworkAccessChecksKillSwitch.json5
@@ -1,0 +1,61 @@
+[
+  {
+    name: 'LocalNetworkAccessChecksKillSwitch',
+    consistency: 'PERMANENT',
+    experiment: [
+      {
+        name: 'Disabled_PrivateNetworkAccessKillSwitch',
+        probability_weight: 100,
+        feature_association: {
+          disable_feature: [
+            'LocalNetworkAccessChecks',
+          ],
+        },
+      },
+    ],
+    filter: {
+      min_version: '141.*',
+      channel: [
+        'NIGHTLY',
+        'BETA',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+        'ANDROID',
+      ],
+    },
+  },
+  {
+    name: 'LocalNetworkAccessChecksKillSwitch',
+    consistency: 'PERMANENT',
+    experiment: [
+      {
+        name: 'Disabled_PrivateNetworkAccessKillSwitch',
+        probability_weight: 5,
+        feature_association: {
+          disable_feature: [
+            'LocalNetworkAccessChecks',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 95,
+      },
+    ],
+    filter: {
+      min_version: '141.*',
+      channel: [
+        'RELEASE',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+        'ANDROID',
+      ],
+    },
+  },
+]


### PR DESCRIPTION
Disables LocalNetworkAccessChecks on Nightly/Beta at 100% and Release at 5%.

For #1523

**Rollout**:
- Nightly/Beta: 100%
- Release: 5%
