### PR TITLE
[ZCash] Disable Zcash on old versions

### DIFF
--- a/studies/ZCashStudy.json5
+++ b/studies/ZCashStudy.json5
@@ -1,0 +1,72 @@
+[
+  {
+    name: 'ZCashStudy_EnabledWithShieldingOnNewVersions',
+    experiment: [
+      {
+        name: 'EnabledWithShielding',
+        probability_weight: 100,
+        feature_association: {
+          disable_feature: [
+            'BraveWalletZCash',
+          ],
+        },
+        param: [
+          {
+            name: 'zcash_shielded_transactions_enabled',
+            value: 'true',
+          },
+        ],
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      min_version: '139.1.81.129',
+      channel: [
+        'RELEASE',
+        'NIGHTLY',
+        'BETA',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+        'ANDROID',
+      ],
+    },
+  },
+  {
+    name: 'ZCashStudy_DisabledOnOldVersions',
+    experiment: [
+      {
+        name: 'Disabled',
+        probability_weight: 100,
+        feature_association: {
+          disable_feature: [
+            'BraveWalletZCash',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      max_version: '139.1.81.128',
+      channel: [
+        'RELEASE',
+        'NIGHTLY',
+        'BETA',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+        'ANDROID',
+      ],
+    },
+  },
+]


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/49840

Test plan:
1) Use 1.80.x version with Zcash + Shielded enabled. Add some accounts, do sync, etc..
2) Apply variations
3) Test that Zcash disappears
4) Update to the 1.81.x version
5) Check accounts are restored and etc.
Test platforms : Desktop + Android