### PR TITLE
Disable EnableBookmarkCodecSHA256: Nightly/Beta 100%, Stable 5%

### DIFF
--- a/studies/EnableBookmarkCodecSHA256KillSwitch.json5
+++ b/studies/EnableBookmarkCodecSHA256KillSwitch.json5
@@ -1,0 +1,61 @@
+[
+  {
+    name: 'EnableBookmarkCodecSHA256KillSwitch',
+    consistency: 'PERMANENT',
+    experiment: [
+      {
+        name: 'Disabled_EnableBookmarkCodecSHA256',
+        probability_weight: 100,
+        feature_association: {
+          disable_feature: [
+            'EnableBookmarkCodecSHA256',
+          ],
+        },
+      },
+    ],
+    filter: {
+      min_version: '142.*',
+      channel: [
+        'NIGHTLY',
+        'BETA',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+        'ANDROID',
+      ],
+    },
+  },
+  {
+    name: 'EnableBookmarkCodecSHA256KillSwitch',
+    consistency: 'PERMANENT',
+    experiment: [
+      {
+        name: 'Disabled_EnableBookmarkCodecSHA256',
+        probability_weight: 5,
+        feature_association: {
+          disable_feature: [
+            'EnableBookmarkCodecSHA256',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 95,
+      },
+    ],
+    filter: {
+      min_version: '142.*',
+      channel: [
+        'RELEASE',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+        'ANDROID',
+      ],
+    },
+  },
+]


### PR DESCRIPTION
Disables EnableBookmarkCodecSHA256 on Nightly/Beta at 100% and Stable at 5%

For #1549

**Rollout**:
- Nightly/Beta: 100%
- Stable: 5%
