### PR TITLE
Disabled search promotion due to startup crash

### DIFF
--- a/studies/BraveSearchPromotionButtonStudy.json5
+++ b/studies/BraveSearchPromotionButtonStudy.json5
@@ -4,7 +4,7 @@
     experiment: [
       {
         name: 'Enabled',
-        probability_weight: 100,
+        probability_weight: 0,
         feature_association: {
           enable_feature: [
             'BraveSearchPromotionOmniboxButton',
@@ -13,7 +13,7 @@
       },
       {
         name: 'Default',
-        probability_weight: 0,
+        probability_weight: 100,
       },
     ],
     filter: {


### PR DESCRIPTION
Promotion button could cause startup crash.
Disabled this study till https://github.com/brave/brave-core/pull/32521 arrives nightly/beta.