### PR TITLE
Revert the recent `BTMGoogleAuthWorkaround` study change

### DIFF
--- a/studies/BTMGoogleAuthWorkaround.json5
+++ b/studies/BTMGoogleAuthWorkaround.json5
@@ -24,7 +24,6 @@
     ],
     filter: {
       min_version: '140.*',
-      max_version: '142.*',
       channel: [
         'NIGHTLY',
         'BETA',


### PR DESCRIPTION
Seems folks are running into issues without this study enabled.

These are folks on recent versions of Brave, not on older builds.

Some sources
- https://www.reddit.com/r/brave_browser/comments/1pemff1/brave_185111_my_google_account_is_getting/
- https://github.com/brave/brave-browser/issues/50411
