### PR TITLE
Restrict prettier to 3.6.* versions.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,6 +24,12 @@
       "schedule": [
         "before 6am on tuesday"
       ]
+    },
+    {
+      "matchPackageNames": [
+        "prettier"
+      ],
+      "allowedVersions": "<3.7"
     }
   ],
   "schedule": [


### PR DESCRIPTION
`prettier-plugin-multiline-arrays` is not compatible with 3.7+ currently

break can be seen here https://github.com/brave/brave-variations/pull/1578

issues in prettier https://github.com/prettier/prettier/issues?q=is%3Aissue%20state%3Aclosed%20getVisitorKeys

```
[error] studies/BraveSearchPromotionBannerStudy.json5: TypeError: getVisitorKeys is not a function or its return value is not iterable
[error]     at recurse (file:///D:/brave/brave-variations/node_modules/prettier/index.mjs:16509:24)
[error]     at printEmbeddedLanguages (file:///D:/brave/brave-variations/node_modules/prettier/index.mjs:16479:3)
[error]     at printAstToDoc (file:///D:/brave/brave-variations/node_modules/prettier/index.mjs:16588:9)
[error]     at async coreFormat (file:///D:/brave/brave-variations/node_modules/prettier/index.mjs:16967:14)
[error]     at async formatWithCursor (file:///D:/brave/brave-variations/node_modules/prettier/index.mjs:17180:14)
[error]     at async formatFiles (file:///D:/brave/brave-variations/node_modules/prettier/internal/legacy-cli.mjs:5831:18)       
[error]     at async main (file:///D:/brave/brave-variations/node_modules/prettier/internal/legacy-cli.mjs:6220:5)
[error]     at async Module.run (file:///D:/brave/brave-variations/node_modules/prettier/internal/legacy-cli.mjs:6163:5)
```