### PR TITLE
Max version for RenderDocument feature.

### DIFF
--- a/studies/RenderDocument.json5
+++ b/studies/RenderDocument.json5
@@ -20,6 +20,7 @@
     ],
     filter: {
       min_version: '142.1.84.141',
+      max_version: '144.1.87.113',
       channel: [
         'RELEASE',
         'NIGHTLY',


### PR DESCRIPTION
Since the fix for `window.name` clearing has been landed (https://github.com/brave/brave-core/pull/32889/), we can remove the workaround that was overriding the upstream feature which fixes clearing in some cases.