### PR TITLE
Enable Omaha 4 for 50% of macOS Nightly users

### DIFF
--- a/studies/UseOmaha4Study.json5
+++ b/studies/UseOmaha4Study.json5
@@ -4,7 +4,7 @@
     experiment: [
       {
         name: 'Enabled',
-        probability_weight: 25,
+        probability_weight: 50,
         feature_association: {
           enable_feature: [
             'BraveUseOmaha4',
@@ -13,7 +13,7 @@
       },
       {
         name: 'Default',
-        probability_weight: 75,
+        probability_weight: 50,
       },
     ],
     filter: {


### PR DESCRIPTION
The stats are looking good so far and we need more data.