### PR TITLE
Add Brave iOS User Agent Type Study

### DIFF
--- a/studies/BraveIOSUserAgentTypeStudy.json5
+++ b/studies/BraveIOSUserAgentTypeStudy.json5
@@ -1,0 +1,31 @@
+[
+  {
+    name: 'BraveIOSUserAgentTypeStudy',
+    experiment: [
+      {
+        name: 'BraveIOSUserAgentType',
+        probability_weight: 100,
+        feature_association: {
+          enable_feature: [
+            'UseBraveUserAgent',
+          ],
+        },
+        param: [
+          {
+            name: 'default_user_agent',
+            value: '1',
+          },
+        ],
+      },
+    ],
+    filter: {
+      min_version: '147.1.89.52',
+      channel: [
+        'NIGHTLY',
+      ],
+      platform: [
+        'IOS',
+      ],
+    },
+  },
+]


### PR DESCRIPTION
Intentional draft PR while testing.

Key|Value|User Agent Used
--|--|--
`default_user_agent`|`0`|Safari UA / masked Brave
`default_user_agent`|`1`|Brave/1
`default_user_agent`|`2`|Safari UA w/ Brave suffix
`default_user_agent`|`3`|Safari UA w/ (Brave) suffix