### PR TITLE
remove prettier<3.7 renovate rule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,12 +24,6 @@
       "schedule": [
         "before 6am on tuesday"
       ]
-    },
-    {
-      "matchPackageNames": [
-        "prettier"
-      ],
-      "allowedVersions": "<3.7"
     }
   ],
   "schedule": [


### PR DESCRIPTION
`prettier` version is already 3.8.0
