### PR TITLE
Add Adblock-Only mode settings toggle and prompt

### DIFF
--- a/studies/AdblockOnlyModeStudy.json5
+++ b/studies/AdblockOnlyModeStudy.json5
@@ -35,4 +35,39 @@
       ],
     },
   },
+  {
+    name: 'AdblockOnlyModeStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 100,
+        feature_association: {
+          enable_feature: [
+            'AdblockOnlyMode',
+          ],
+        },
+        param: [
+          {
+            name: 'prompt_after_shields_disabled_count',
+            value: '3',
+          },
+        ],
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      min_version: '145.1.88.96',
+      channel: [
+        'RELEASE',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+      ],
+    },
+  },
 ]


### PR DESCRIPTION
The PR adds an option for users to enable `Adblock Only Mode` either through a toggle on the Settings page or through a prompt in the Shields panel. Prompt is shown when user disables Shields 3 or more times. 
`Adblock Only Mode` is disabled by default.

Within `Adblock Only Mode` (when it is enabled by the toggle or via prompt), blocking ads functionality is enabled, but some other privacy protections typically enabled by Shields are disabled. This offer a solution to webcompat issues for less technical users.

Functionality will be available in Release channel starting from version `1.88.96` (this is the version where the last ABOM change was merged: https://github.com/brave/brave-core/pull/33393)

Testing plan is available at https://github.com/brave/brave-browser/issues/48521.