### PR TITLE
Rollout AI Chat Conversation API V2 at 25% in Release

### DIFF
--- a/studies/BraveAIChatConversationAPIV2Study.json5
+++ b/studies/BraveAIChatConversationAPIV2Study.json5
@@ -58,7 +58,6 @@
         'MAC',
         'LINUX',
         'ANDROID',
-        'IOS',
       ],
     },
   },

--- a/studies/BraveAIChatConversationAPIV2Study.json5
+++ b/studies/BraveAIChatConversationAPIV2Study.json5
@@ -31,4 +31,35 @@
       ],
     },
   },
+  {
+    name: 'BraveAIChatConversationAPIV2Study',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 25,
+        feature_association: {
+          enable_feature: [
+            'AIChatConversationAPIV2',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 75,
+      },
+    ],
+    filter: {
+      min_version: '147.1.89.132',
+      channel: [
+        'RELEASE',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+        'ANDROID',
+        'IOS',
+      ],
+    },
+  },
 ]


### PR DESCRIPTION
Enabled on Beta and Nightly before via https://github.com/brave/brave-variations/pull/1643 and https://github.com/brave/brave-variations/pull/1626.
This PR is to rollout at 25% in Release (1.89.x).
iOS is first excluded for now, will rollout later once we start releasing 1.89.x on iOS.