### PR TITLE
Enable Brave Shields Content Settings on iOS at 50% in Release

### DIFF
--- a/studies/BraveShieldsContentSettingsIOS.json5
+++ b/studies/BraveShieldsContentSettingsIOS.json5
@@ -32,7 +32,7 @@
     experiment: [
       {
         name: 'Enabled',
-        probability_weight: 25,
+        probability_weight: 50,
         feature_association: {
           enable_feature: [
             'BraveShieldsContentSettingsIOS',
@@ -41,7 +41,7 @@
       },
       {
         name: 'Default',
-        probability_weight: 75,
+        probability_weight: 50,
       },
     ],
     filter: {


### PR DESCRIPTION
Enabled in release at 25% since March 31st: https://github.com/brave/brave-variations/pull/1648