### PR TITLE
Enable ShouldCancelRequestsForUserAgentChange at 100% on iOS in Beta & Nightly

### DIFF
--- a/studies/ShouldCancelRequestsForUserAgentChange.json5
+++ b/studies/ShouldCancelRequestsForUserAgentChange.json5
@@ -1,0 +1,30 @@
+[
+  {
+    name: 'ShouldCancelRequestsForUserAgentChange',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 100,
+        feature_association: {
+          enable_feature: [
+            'ShouldCancelRequestsForUserAgentChange',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      min_version: '147.1.91.65',
+      channel: [
+        'NIGHTLY',
+        'BETA',
+      ],
+      platform: [
+        'IOS',
+      ],
+    },
+  },
+]


### PR DESCRIPTION
This flag resolves https://github.com/brave/brave-browser/issues/54479.

The feature is being uplifted to Release where flag can be enabled manually, but only enabling via Griffin in Beta & Nightly to test before release.