### PR TITLE
Enable ForceContextMenuOnShiftRightClick by default

### DIFF
--- a/studies/ForceContextMenuOnShiftRightClickStudy.json5
+++ b/studies/ForceContextMenuOnShiftRightClickStudy.json5
@@ -1,0 +1,32 @@
+[
+  {
+    name: 'ForceContextMenuOnShiftRightClickStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 100,
+        feature_association: {
+          enable_feature: [
+            'ForceContextMenuOnShiftRightClick',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      min_version: '147.1.89.137',
+      channel: [
+        'BETA',
+        'NIGHTLY',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+      ],
+    },
+  },
+]


### PR DESCRIPTION
100% to Beta and Nightly

For the functionality, please see:
- https://github.com/brave/brave-browser/issues/25715
- https://github.com/brave/brave-core/pull/31770