### PR TITLE
Begin to enable `ForceContextMenuOnShiftRightClick` on Release channel

### DIFF
--- a/studies/ForceContextMenuOnShiftRightClickStudy.json5
+++ b/studies/ForceContextMenuOnShiftRightClickStudy.json5
@@ -29,4 +29,33 @@
       ],
     },
   },
+  {
+    name: 'ForceContextMenuOnShiftRightClickStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 25,
+        feature_association: {
+          enable_feature: [
+            'ForceContextMenuOnShiftRightClick',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 75,
+      },
+    ],
+    filter: {
+      min_version: '147.1.89.137',
+      channel: [
+        'RELEASE',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+      ],
+    },
+  },
 ]


### PR DESCRIPTION
Starts off at 25% enabled

Release channel version of https://github.com/brave/brave-variations/pull/1679