### PR TITLE
Enable Brave Shields Content Settings on iOS at 100% in Release.

### DIFF
--- a/studies/BraveShieldsContentSettingsIOS.json5
+++ b/studies/BraveShieldsContentSettingsIOS.json5
@@ -19,35 +19,9 @@
     filter: {
       min_version: '143.1.87.77',
       channel: [
+        'RELEASE',
         'NIGHTLY',
         'BETA',
-      ],
-      platform: [
-        'IOS',
-      ],
-    },
-  },
-  {
-    name: 'BraveShieldsContentSettingsIOS_Release',
-    experiment: [
-      {
-        name: 'Enabled',
-        probability_weight: 50,
-        feature_association: {
-          enable_feature: [
-            'BraveShieldsContentSettingsIOS',
-          ],
-        },
-      },
-      {
-        name: 'Default',
-        probability_weight: 50,
-      },
-    ],
-    filter: {
-      min_version: '143.1.87.77',
-      channel: [
-        'RELEASE',
       ],
       platform: [
         'IOS',


### PR DESCRIPTION
Enabled at 50% since April 13th: https://github.com/brave/brave-variations/pull/1664#event-24463466553