### PR TITLE
Set iOS wallet webui 25% on release (1.89.x) 

### DIFF
--- a/studies/iOSWalletWebUIStudy.json5
+++ b/studies/iOSWalletWebUIStudy.json5
@@ -58,4 +58,65 @@
       ],
     },
   },
+  {
+    name: 'iOSWalletWebUIStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 25,
+        feature_association: {
+          enable_feature: [
+            'BraveWalletWebUIFeature',
+            'BraveWalletCardano',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 75,
+      },
+    ],
+    filter: {
+      min_version: '147.1.89.144',
+      channel: [
+        'RELEASE',
+      ],
+      platform: [
+        'IOS',
+      ],
+    },
+  },
+  {
+    name: 'iOSWalletWebUIStudy_ZcashEnabledWithShielding',
+    experiment: [
+      {
+        name: 'EnabledWithShielding',
+        probability_weight: 100,
+        feature_association: {
+          enable_feature: [
+            'BraveWalletZCash',
+          ],
+        },
+        param: [
+          {
+            name: 'zcash_shielded_transactions_enabled',
+            value: 'true',
+          },
+        ],
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      min_version: '147.1.89.144',
+      channel: [
+        'RELEASE',
+      ],
+      platform: [
+        'IOS',
+      ],
+    },
+  },
 ]


### PR DESCRIPTION
We will set iOS Wallet WebUI 25% on release 
Shielded Zcash to 100% on release, since shielded Zcash only available via WebUI