### PR TITLE
Enable containers on BETA with cr148 on 50%.

### DIFF
--- a/studies/BraveContainers.json5
+++ b/studies/BraveContainers.json5
@@ -37,4 +37,42 @@
       ],
     },
   },
+  {
+    name: 'BraveContainers',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 50,
+        feature_association: {
+          enable_feature: [
+            'Containers',
+          ],
+        },
+      },
+      {
+        name: 'Disabled',
+        probability_weight: 50,
+        feature_association: {
+          disable_feature: [
+            'Containers',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      min_version: '148.1.91.38',
+      channel: [
+        'BETA',
+      ],
+      platform: [
+        'LINUX',
+        'MAC',
+        'WINDOWS',
+      ],
+    },
+  },
 ]


### PR DESCRIPTION
Enable Containers on BETA starting with cr148.

Related https://github.com/brave/brave-browser/issues/46349