### PR TITLE
Enable DefaultPassthroughCommandDecoder on Android Nightly/Beta

### DIFF
--- a/studies/DefaultPassthroughCommandDecoderStudy.json5
+++ b/studies/DefaultPassthroughCommandDecoderStudy.json5
@@ -3,6 +3,41 @@
     name: 'DefaultPassthroughCommandDecoderStudy',
     experiment: [
       {
+        name: 'Enabled',
+        probability_weight: 100,
+        feature_association: {
+          enable_feature: [
+            'DefaultPassthroughCommandDecoder',
+            'GpuPersistentCache',
+          ],
+        },
+        param: [
+          {
+            name: 'BlockListByModel',
+            value: 'SM-I610|SM-I610H|Robin XR',
+          },
+        ],
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      min_version: '148.*',
+      channel: [
+        'NIGHTLY',
+        'BETA',
+      ],
+      platform: [
+        'ANDROID',
+      ],
+    },
+  },
+  {
+    name: 'DefaultPassthroughCommandDecoderStudy',
+    experiment: [
+      {
         name: 'Disabled',
         probability_weight: 100,
         feature_association: {
@@ -19,8 +54,6 @@
     filter: {
       min_version: '125.*',
       channel: [
-        'NIGHTLY',
-        'BETA',
         'RELEASE',
       ],
       platform: [


### PR DESCRIPTION
Mirrors upstream's rollout (Launched_CLANK_20260508) by enabling DefaultPassthroughCommandDecoder + GpuPersistentCache at 100% on Android Nightly/Beta with the upstream BlockListByModel param. Release stays on the existing 100% Disabled arm until Nightly/Beta telemetry looks clean.

Resolves: https://github.com/brave/brave-variations/issues/1702