### PR TITLE
Enable iOS Wallet WebUI at 100% in Release

### DIFF
--- a/studies/iOSWalletWebUIStudy.json5
+++ b/studies/iOSWalletWebUIStudy.json5
@@ -63,7 +63,7 @@
     experiment: [
       {
         name: 'Enabled',
-        probability_weight: 25,
+        probability_weight: 100,
         feature_association: {
           enable_feature: [
             'BraveWalletWebUIFeature',
@@ -73,7 +73,7 @@
       },
       {
         name: 'Default',
-        probability_weight: 75,
+        probability_weight: 0,
       },
     ],
     filter: {


### PR DESCRIPTION
was at 25% since May 12th. we will ramp up faster to set it to 100% since iOS wallet user is fairly low. 