### PR TITLE
Enable DefaultPassthroughCommandDecoder on Android Release at 15%

### DIFF
--- a/studies/DefaultPassthroughCommandDecoderStudy.json5
+++ b/studies/DefaultPassthroughCommandDecoderStudy.json5
@@ -53,6 +53,46 @@
     ],
     filter: {
       min_version: '125.*',
+      max_version: '147.*',
+      channel: [
+        'RELEASE',
+      ],
+      platform: [
+        'ANDROID',
+      ],
+    },
+  },
+  {
+    name: 'DefaultPassthroughCommandDecoderStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 15,
+        feature_association: {
+          enable_feature: [
+            'DefaultPassthroughCommandDecoder',
+            'GpuPersistentCache',
+          ],
+        },
+        param: [
+          {
+            name: 'BlockListByModel',
+            value: 'SM-I610|SM-I610H|Robin XR',
+          },
+        ],
+      },
+      {
+        name: 'Disabled',
+        probability_weight: 85,
+        feature_association: {
+          disable_feature: [
+            'DefaultPassthroughCommandDecoder',
+          ],
+        },
+      },
+    ],
+    filter: {
+      min_version: '148.*',
       channel: [
         'RELEASE',
       ],


### PR DESCRIPTION
Roll out DefaultPassthroughCommandDecoder + GpuPersistentCache to 15% of Android Release users on 148+, with 85% explicitly disabled. Bound the existing 125.* Disabled entry with max_version 147.* so 148+ devices don't match both studies and receive conflicting directives.

Resolves: https://github.com/brave/brave-variations/issues/1719