### PR TITLE
Stop AI chat conversation API v2 study at 147.1.91.31

### DIFF
--- a/studies/BraveAIChatConversationAPIV2Study.json5
+++ b/studies/BraveAIChatConversationAPIV2Study.json5
@@ -18,6 +18,7 @@
     ],
     filter: {
       min_version: '146.1.89.81',
+      max_version: '147.1.91.31',
       channel: [
         'BETA',
         'NIGHTLY',
@@ -50,6 +51,7 @@
     ],
     filter: {
       min_version: '147.1.89.132',
+      max_version: '147.1.91.31',
       channel: [
         'RELEASE',
       ],


### PR DESCRIPTION
Feature flag enabled by default in the code base at 1.91.31. https://github.com/brave/brave-core/pull/35298#issuecomment-4218011036
We're removing this feature flag in the code base in 1.93.x via https://github.com/brave/brave-core/pull/36767.