### PR TITLE
Bump conversation API v2 stop version to start with CR148

### DIFF
--- a/studies/BraveAIChatConversationAPIV2Study.json5
+++ b/studies/BraveAIChatConversationAPIV2Study.json5
@@ -18,7 +18,7 @@
     ],
     filter: {
       min_version: '146.1.89.81',
-      max_version: '147.1.91.31',
+      max_version: '148.1.91.31',
       channel: [
         'BETA',
         'NIGHTLY',
@@ -51,7 +51,7 @@
     ],
     filter: {
       min_version: '147.1.89.132',
-      max_version: '147.1.91.31',
+      max_version: '148.1.91.31',
       channel: [
         'RELEASE',
       ],


### PR DESCRIPTION
This would mean we stop the study after any 1.91.x with CR148.