### PR TITLE
Bump DefaultPassthroughCommandDecoder on Android Release from 15% to 30%

### DIFF
--- a/studies/DefaultPassthroughCommandDecoderStudy.json5
+++ b/studies/DefaultPassthroughCommandDecoderStudy.json5
@@ -67,7 +67,7 @@
     experiment: [
       {
         name: 'Enabled',
-        probability_weight: 15,
+        probability_weight: 30,
         feature_association: {
           enable_feature: [
             'DefaultPassthroughCommandDecoder',
@@ -83,7 +83,7 @@
       },
       {
         name: 'Disabled',
-        probability_weight: 85,
+        probability_weight: 70,
         feature_association: {
           disable_feature: [
             'DefaultPassthroughCommandDecoder',


### PR DESCRIPTION
Resolves: https://github.com/brave/brave-variations/issues/1728