### PR TITLE
Enforce pnpm as a package manager to prevent npm install to work.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,10 +45,18 @@
     "webpack-cli": "7.0.2",
     "webpack-dev-server": "5.2.4"
   },
-  "engines": {
-    "node": ">=22.0.0"
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": ">=22.0.0",
+      "onFail": "error"
+    },
+    "packageManager": {
+      "name": "pnpm",
+      "version": ">=10.29.2",
+      "onFail": "error"
+    }
   },
-  "packageManager": "pnpm@10.29.2+sha512.bef43fa759d91fd2da4b319a5a0d13ef7a45bb985a3d7342058470f9d2051a3ba8674e629672654686ef9443ad13a82da2beb9eeb3e0221c87b8154fff9d74b8",
   "type": "commonjs",
   "license": "MPL-2.0",
   "moduleResolution": "node",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+allowBuilds:
+  esbuild: false
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
   - fast-uri@3.1.2

--- a/src/scripts/generate_proto_ts.ts
+++ b/src/scripts/generate_proto_ts.ts
@@ -55,8 +55,7 @@ function generateProtobufTs() {
     gitApplyStudyProtoPatch();
     execSync(
       [
-        'npx',
-        '--',
+        'pnx',
         'protoc',
         '--ts_out',
         protoGeneratedDir,


### PR DESCRIPTION
Use `devEngines` field as a hard stop to prevent `npm install` to work. Without this `npm install` will be happy to roll whatever is written in `package.json` with all most recent sub-dependencies, because there's no lock file for npm.