### PR TITLE
Enable HistoryEmbeddings in Nightly

### DIFF
--- a/studies/HistoryEmbeddingsStudy.json5
+++ b/studies/HistoryEmbeddingsStudy.json5
@@ -1,0 +1,41 @@
+[
+  {
+    name: 'HistoryEmbeddingsStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 100,
+        feature_association: {
+          enable_feature: [
+            'HistoryEmbeddings',
+          ],
+        },
+        param: [
+          {
+            name: 'WordMatchMinEmbeddingScore',
+            value: '0.4',
+          },
+          {
+            name: 'WordMatchRequiredTermRatio',
+            value: '0.8',
+          },
+        ],
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      min_version: '150.1.94.73',
+      channel: [
+        'NIGHTLY',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+      ],
+    },
+  },
+]


### PR DESCRIPTION
It is safe to enable it 100% in nightly because users still need to opt-in to get this feature running
The toggle was introduced in https://github.com/brave/brave-core/pull/36624