### PR TITLE
Enable `load_after_restore` for `BraveSearchBackupResults`

### DIFF
--- a/studies/BraveSearchBackupResultsStudy.json5
+++ b/studies/BraveSearchBackupResultsStudy.json5
@@ -1,0 +1,39 @@
+[
+  {
+    name: 'BraveSearchBackupResultsStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 100,
+        feature_association: {
+          enable_feature: [
+            'BraveSearchBackupResults',
+          ],
+        },
+        param: [
+          {
+            name: 'load_after_restore',
+            value: 'true',
+          },
+        ],
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      channel: [
+        'NIGHTLY',
+        'BETA',
+        'RELEASE',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+        'ANDROID',
+      ],
+    },
+  },
+]


### PR DESCRIPTION
Rolling out the change described in https://github.com/brave/internal/issues/1762. QA is optional