### PR TITLE
Update README.md for lint/fix command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A continuous integration server (CI) serializes and signs the updated seed file 
 1. Run `pnpm install` after checking out the repository.
 2. Create or modify a study file in `studies` directory, following the protobuf
    schema in [`src/proto/study.proto`](/src/proto/study.proto).
-3. Run `pnpm seed_tools lint -- --fix` and address found issues.
+3. Run `pnpm seed_tools lint --fix` and address found issues.
 4. Create a Pull Request targeting the `main` branch.
 5. Follow the PR instructions to verify that everything works as intended.
 


### PR DESCRIPTION
With the original
```
3. Run `pnpm seed_tools lint -- --fix` and address found issues.
```

I got

```
$ pnpm seed_tools lint -- --fix
$ tsx src/seed_tools/seed_tools.ts lint -- --fix
node:internal/fs/promises:956
  const result = await PromisePrototypeThen(
                 ^

Error: ENOENT: no such file or directory, scandir '--fix'
    at async Object.readdir (node:internal/fs/promises:956:18)
    at async readStudiesFromDirectory (/home/****/brave-variations/src/seed_tools/utils/studies_to_seed.ts:58:18)
    at async readStudiesToSeed (/home/****/brave-variations/src/seed_tools/utils/studies_to_seed.ts:33:7)
    at async Command.lintStudies (/home/****/brave-variations/src/seed_tools/commands/lint.ts:26:38) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'scandir',
  path: '--fix'
}
```

Worked fine with
```
3. Run `pnpm seed_tools lint --fix` and address found issues.
```