### PR TITLE
Study to verify --variations-pr= command on Android cr150

### DIFF
--- a/studies/TestCmdLineVariationsPrDoNotMerge.json5
+++ b/studies/TestCmdLineVariationsPrDoNotMerge.json5
@@ -1,0 +1,31 @@
+[
+  {
+    name: 'TestCmdLineVariationsPrDoNotMerge',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 100,
+        feature_association: {
+          enable_feature: [
+            'BraveAndroidDynamicColors',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      min_version: '127.1.68.107',
+      channel: [
+        'NIGHTLY',
+        'BETA',
+        'RELEASE',
+      ],
+      platform: [
+        'ANDROID',
+      ],
+    },
+  },
+]


### PR DESCRIPTION
This is a study to verify the command argument `--variations-pr=`  works fine  on Android cr150.
Should not be merged.
Review is not required.