### PR TITLE
[iOS] Disable `NetworkConnectionIntegrityStudy` on all channels

### DIFF
--- a/studies/NetworkConnectionIntegrityStudy.json5
+++ b/studies/NetworkConnectionIntegrityStudy.json5
@@ -4,7 +4,7 @@
     experiment: [
       {
         name: 'Enabled',
-        probability_weight: 100,
+        probability_weight: 0,
         feature_association: {
           enable_feature: [
             'WebKitAdvancedPrivacyProtections',
@@ -13,7 +13,7 @@
       },
       {
         name: 'Default',
-        probability_weight: 0,
+        probability_weight: 100,
       },
     ],
     filter: {


### PR DESCRIPTION
Currently only enabled via Griffin on Nightly.
Disabling temporarily due to page load issues on iOS 27 betas, `brave://flags` won't load so it can only be disabled from Developer Options / QA Menu switches.