### PR TITLE
Adblock DAT cache enablement in Nightly/Beta

### DIFF
--- a/studies/BraveAdblockDATCacheStudy.json5
+++ b/studies/BraveAdblockDATCacheStudy.json5
@@ -1,0 +1,33 @@
+[
+  {
+    name: 'BraveAdblockDATCacheStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 100,
+        feature_association: {
+          enable_feature: [
+            'AdblockDATCache',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      min_version: '148.1.91.162',
+      channel: [
+        'BETA',
+        'NIGHTLY',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+        'ANDROID',
+      ],
+    },
+  },
+]


### PR DESCRIPTION
We added this functionality in https://github.com/brave/brave-core/pull/35069 and also verified it but never enabled the Griffin flag. Enabling in Nightly and Beta.