### PR TITLE
Enable DefaultPassthroughCommandDecoder on Android Release at 100%

### DIFF
--- a/studies/DefaultPassthroughCommandDecoderStudy.json5
+++ b/studies/DefaultPassthroughCommandDecoderStudy.json5
@@ -28,6 +28,7 @@
       channel: [
         'NIGHTLY',
         'BETA',
+        'RELEASE',
       ],
       platform: [
         'ANDROID',
@@ -54,45 +55,6 @@
     filter: {
       min_version: '125.*',
       max_version: '147.*',
-      channel: [
-        'RELEASE',
-      ],
-      platform: [
-        'ANDROID',
-      ],
-    },
-  },
-  {
-    name: 'DefaultPassthroughCommandDecoderStudy',
-    experiment: [
-      {
-        name: 'Enabled',
-        probability_weight: 90,
-        feature_association: {
-          enable_feature: [
-            'DefaultPassthroughCommandDecoder',
-            'GpuPersistentCache',
-          ],
-        },
-        param: [
-          {
-            name: 'BlockListByModel',
-            value: 'SM-I610|SM-I610H|Robin XR|Android XR Puck|Aura',
-          },
-        ],
-      },
-      {
-        name: 'Disabled',
-        probability_weight: 10,
-        feature_association: {
-          disable_feature: [
-            'DefaultPassthroughCommandDecoder',
-          ],
-        },
-      },
-    ],
-    filter: {
-      min_version: '148.*',
       channel: [
         'RELEASE',
       ],


### PR DESCRIPTION
Resolves https://github.com/brave/brave-variations/issues/1762