### PR TITLE
Require node>=24 and pnpm>=11.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,12 +47,12 @@
   "devEngines": {
     "runtime": {
       "name": "node",
-      "version": ">=22.0.0",
+      "version": ">=24",
       "onFail": "error"
     },
     "packageManager": {
       "name": "pnpm",
-      "version": ">=10.29.2",
+      "version": ">=11",
       "onFail": "error"
     }
   },


### PR DESCRIPTION
CI has v11.

https://ci.brave.com/job/brave-browser-variations-publish-staging/2023/