### PR TITLE
Enable BraveRequestInfoUniquePtr study on beta

### DIFF
--- a/studies/BraveRequestInfoUniquePtrStudy.json5
+++ b/studies/BraveRequestInfoUniquePtrStudy.json5
@@ -19,6 +19,7 @@
     filter: {
       channel: [
         'NIGHTLY',
+        'BETA',
       ],
       platform: [
         'WINDOWS',


### PR DESCRIPTION
## Summary

Adds `BETA` to `BraveRequestInfoUniquePtrStudy`, which is already rolling out the `BraveRequestInfoUniquePtr` feature at 100% on Nightly for Windows, macOS, Linux, and Android.

## Verification

Ran with `COREPACK_ENABLE_PROJECT_SPEC=0` because this checkout's `devEngines.packageManager.version` is `>=11.9.0`, which Corepack rejects as a package-manager specifier. The actual pnpm version used was `11.17.0`.

- `pnpm install --frozen-lockfile`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test`
