### PR TITLE
Enable BraveRequestInfoUniquePtr at 100% for all channels

### DIFF
--- a/studies/BraveRequestInfoUniquePtrStudy.json5
+++ b/studies/BraveRequestInfoUniquePtrStudy.json5
@@ -19,6 +19,8 @@
     filter: {
       channel: [
         'NIGHTLY',
+        'BETA',
+        'RELEASE',
       ],
       platform: [
         'WINDOWS',


### PR DESCRIPTION
Moving UniquePtr to all channels. No issues or crashes detected, but there is an existing crash for shared_ptr that this addresses https://share.backtrace.io/api/share/x2HaLpmrI3Kx3ihGeNDx2H6x11