### PR TITLE
Roll out Brave Ads oblivious HTTP to 10% on Release

### DIFF
--- a/studies/BraveAdsObliviousHttpStudy.json5
+++ b/studies/BraveAdsObliviousHttpStudy.json5
@@ -37,4 +37,41 @@
       ],
     },
   },
+  {
+    name: 'BraveAdsObliviousHttpStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 10,
+        feature_association: {
+          enable_feature: [
+            'AdsObliviousHttpFeature',
+          ],
+        },
+        param: [
+          {
+            name: 'should_support',
+            value: 'true',
+          },
+        ],
+      },
+      {
+        name: 'Default',
+        probability_weight: 90,
+      },
+    ],
+    filter: {
+      min_version: '145.1.87.67',
+      channel: [
+        'RELEASE',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+        'ANDROID',
+        'IOS',
+      ],
+    },
+  },
 ]


### PR DESCRIPTION
Adds a RELEASE channel block at 10% Enabled / 90% Default, gated on the same min_version as the existing Nightly/Beta rollout.