### PR TITLE
[BraveRequestInfoUniquePtr] Add a max version as default value was changed

### DIFF
--- a/studies/BraveRequestInfoUniquePtrStudy.json5
+++ b/studies/BraveRequestInfoUniquePtrStudy.json5
@@ -17,6 +17,7 @@
       },
     ],
     filter: {
+      max_version: '151.1.95.13',
       channel: [
         'NIGHTLY',
       ],


### PR DESCRIPTION
See https://github.com/brave/brave-core/pull/38453 for where default value was changed

I think it makes sense to let that ride the trains (or uplift if needed) and more towards deprecating the Griffin flag
