### PR TITLE
Roll out Brave Ads oblivious HTTP to 50% on Release

### DIFF
--- a/studies/BraveAdsObliviousHttpStudy.json5
+++ b/studies/BraveAdsObliviousHttpStudy.json5
@@ -42,7 +42,7 @@
     experiment: [
       {
         name: 'Enabled',
-        probability_weight: 10,
+        probability_weight: 50,
         feature_association: {
           enable_feature: [
             'AdsObliviousHttpFeature',
@@ -57,7 +57,7 @@
       },
       {
         name: 'Default',
-        probability_weight: 90,
+        probability_weight: 50,
       },
     ],
     filter: {


### PR DESCRIPTION
Roll out Brave Ads oblivious HTTP to 50% on Release.