### PR TITLE
Enable HistoryEmbeddings in Nightly

### DIFF
--- a/studies/HistoryEmbeddingsStudy.json5
+++ b/studies/HistoryEmbeddingsStudy.json5
@@ -1,0 +1,41 @@
+[
+  {
+    name: 'HistoryEmbeddingsStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 100,
+        feature_association: {
+          enable_feature: [
+            'HistoryEmbeddings',
+          ],
+        },
+        param: [
+          {
+            name: 'WordMatchMinEmbeddingScore',
+            value: '0.4',
+          },
+          {
+            name: 'WordMatchRequiredTermRatio',
+            value: '0.8',
+          },
+        ],
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      min_version: '152.1.96.13',
+      channel: [
+        'NIGHTLY',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+      ],
+    },
+  },
+]


### PR DESCRIPTION
Basically same as https://github.com/brave/brave-variations/pull/1742, bumped the version to include LiteRT integration