### PR TITLE
Roll out Brave Ads oblivious HTTP to 100% on Release

### DIFF
--- a/studies/BraveAdsObliviousHttpStudy.json5
+++ b/studies/BraveAdsObliviousHttpStudy.json5
@@ -27,42 +27,6 @@
       channel: [
         'NIGHTLY',
         'BETA',
-      ],
-      platform: [
-        'WINDOWS',
-        'MAC',
-        'LINUX',
-        'ANDROID',
-        'IOS',
-      ],
-    },
-  },
-  {
-    name: 'BraveAdsObliviousHttpStudy',
-    experiment: [
-      {
-        name: 'Enabled',
-        probability_weight: 50,
-        feature_association: {
-          enable_feature: [
-            'AdsObliviousHttpFeature',
-          ],
-        },
-        param: [
-          {
-            name: 'should_support',
-            value: 'true',
-          },
-        ],
-      },
-      {
-        name: 'Default',
-        probability_weight: 50,
-      },
-    ],
-    filter: {
-      min_version: '145.1.87.67',
-      channel: [
         'RELEASE',
       ],
       platform: [


### PR DESCRIPTION
Bumps Release from 50% to 100% and merges the Release study entry
into the existing Nightly/Beta entry, since all channels now share
the same rollout percentage.