### PR TITLE
Enable Android dynamic colors default via Griffin

### DIFF
--- a/studies/BraveAndroidDynamicColorsByDefaultStudy.json5
+++ b/studies/BraveAndroidDynamicColorsByDefaultStudy.json5
@@ -1,0 +1,31 @@
+[
+  {
+    name: 'BraveAndroidDynamicColorsByDefaultStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 100,
+        feature_association: {
+          enable_feature: [
+            'BraveAndroidDynamicColorsByDefault',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      min_version: '151.1.95.66',
+      channel: [
+        'NIGHTLY',
+        'BETA',
+        'RELEASE',
+      ],
+      platform: [
+        'ANDROID',
+      ],
+    },
+  },
+]

--- a/studies/BraveAndroidDynamicColorsByDefaultStudy.json5
+++ b/studies/BraveAndroidDynamicColorsByDefaultStudy.json5
@@ -20,8 +20,6 @@
       min_version: '151.1.95.66',
       channel: [
         'NIGHTLY',
-        'BETA',
-        'RELEASE',
       ],
       platform: [
         'ANDROID',


### PR DESCRIPTION
Starting version [`1.95.66`](https://github.com/brave/brave-core/pull/39024#issuecomment-5274232465).

Resolves https://github.com/brave/brave-variations/issues/1815.

Tracks brave/brave-browser#57121 and brave/brave-core#39024.