### PR TITLE
Re-enable BraveAdblockDATCacheStudy in Release at 50%

### DIFF
--- a/studies/BraveAdblockDATCacheStudy.json5
+++ b/studies/BraveAdblockDATCacheStudy.json5
@@ -30,4 +30,35 @@
       ],
     },
   },
+  {
+    name: 'BraveAdblockDATCacheStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 50,
+        feature_association: {
+          enable_feature: [
+            'AdblockDATCache',
+          ],
+        },
+      },
+      {
+        name: 'Default',
+        probability_weight: 50,
+      },
+    ],
+    filter: {
+      min_version: '148.1.91.162',
+      max_version: '152.1.95.78',
+      channel: [
+        'RELEASE',
+      ],
+      platform: [
+        'WINDOWS',
+        'MAC',
+        'LINUX',
+        'ANDROID',
+      ],
+    },
+  },
 ]


### PR DESCRIPTION
Reland of #1787, which was reverted in #1791 while brave/brave-browser#57739 was open. brave/brave-core#39043 has since landed (1.95.x), so the release rollout is unblocked.