### PR TITLE
Set max_version for studies (part 4)

### DIFF
--- a/studies/BraveAggressiveModeRetirementExperiment.json5
+++ b/studies/BraveAggressiveModeRetirementExperiment.json5
@@ -18,6 +18,7 @@
     ],
     filter: {
       min_version: '120.1.63.110',
+      max_version: '152.*',
       channel: [
         'NIGHTLY',
         'BETA',

--- a/studies/BraveAutoTranslateStudy.json5
+++ b/studies/BraveAutoTranslateStudy.json5
@@ -18,6 +18,7 @@
     ],
     filter: {
       min_version: '107.1.47.31',
+      max_version: '152.*',
       channel: [
         'NIGHTLY',
         'BETA',

--- a/studies/BraveFeedUpdateStudy.json5
+++ b/studies/BraveFeedUpdateStudy.json5
@@ -17,6 +17,7 @@
       },
     ],
     filter: {
+      max_version: '152.*',
       channel: [
         'RELEASE',
       ],

--- a/studies/BraveScreenFingerprintingBlockerStudy.json5
+++ b/studies/BraveScreenFingerprintingBlockerStudy.json5
@@ -18,6 +18,7 @@
     ],
     filter: {
       min_version: '108.1.48.19',
+      max_version: '152.*',
       channel: [
         'NIGHTLY',
       ],
@@ -47,6 +48,7 @@
     ],
     filter: {
       min_version: '111.1.50.93',
+      max_version: '152.*',
       channel: [
         'BETA',
       ],
@@ -76,6 +78,7 @@
     ],
     filter: {
       min_version: '111.1.50.93',
+      max_version: '152.*',
       channel: [
         'RELEASE',
       ],

--- a/studies/BraveTranslateiOSStudy.json5
+++ b/studies/BraveTranslateiOSStudy.json5
@@ -17,6 +17,7 @@
       },
     ],
     filter: {
+      max_version: '152.*',
       channel: [
         'RELEASE',
         'NIGHTLY',

--- a/studies/BuiltInAIAPIsDisabledStudy.json5
+++ b/studies/BuiltInAIAPIsDisabledStudy.json5
@@ -25,6 +25,7 @@
       },
     ],
     filter: {
+      max_version: '152.*',
       channel: [
         'RELEASE',
         'BETA',

--- a/studies/PartitionVisitedLinkDatabaseWithSelfLinks.json5
+++ b/studies/PartitionVisitedLinkDatabaseWithSelfLinks.json5
@@ -18,6 +18,7 @@
     ],
     filter: {
       min_version: '134.1.77.83',
+      max_version: '152.*',
       channel: [
         'NIGHTLY',
         'BETA',
@@ -49,6 +50,7 @@
     ],
     filter: {
       min_version: '134.1.77.83',
+      max_version: '152.*',
       channel: [
         'RELEASE',
       ],

--- a/studies/UndecryptablePasswords.json5
+++ b/studies/UndecryptablePasswords.json5
@@ -18,6 +18,7 @@
     ],
     filter: {
       min_version: '127.1.68.107',
+      max_version: '152.*',
       channel: [
         'NIGHTLY',
         'BETA',

--- a/studies/WorkaroundNewWindowFlash.json5
+++ b/studies/WorkaroundNewWindowFlash.json5
@@ -27,6 +27,7 @@
     ],
     filter: {
       min_version: '127.1.70.49',
+      max_version: '152.*',
       channel: [
         'NIGHTLY',
         'BETA',
@@ -64,6 +65,7 @@
     ],
     filter: {
       min_version: '127.1.70.49',
+      max_version: '152.*',
       channel: [
         'RELEASE',
       ],


### PR DESCRIPTION
For https://github.com/brave/brave-variations/pull/1842
| feature | platform / specific filters | brave-variations state | code state in latest stable (v1.93.138) |
|---|---|---|---|
| Blink AI APIs (`AIPromptAPI`, `AIPromptAPIMultimodalInput`, `AIRewriterAPI`, `AISummarizationAPI`, `AIWriterAPI`, `LanguageDetectionAPI`, `TranslationAPI`, `AIProofreadingAPI`) | all platforms | [BuiltInAIAPIsDisabledStudy](https://github.com/brave/brave-variations/blob/main/studies/BuiltInAIAPIsDisabledStudy.json5): **100%** disable | [DISABLED](https://github.com/brave/brave-core/blob/v1.93.138/chromium_src/third_party/blink/common/features_generated.cc#L13) |
| `SkipUndecryptablePasswords` | desktop | [UndecryptablePasswords](https://github.com/brave/brave-variations/blob/main/studies/UndecryptablePasswords.json5): **100%** enabled | [ENABLED](https://github.com/brave/brave-core/blob/v1.93.138/rewrite/components/password_manager/core/browser/features/password_features.cc.yaml#L10 ) |
| `BraveWorkaroundNewWindowFlash` | WINDOWS | [WorkaroundNewWindowFlash](https://github.com/brave/brave-variations/blob/main/studies/WorkaroundNewWindowFlash.json5): **100%** enabled | [ENABLED](https://github.com/brave/brave-core/blob/v1.93.138/browser/ui/brave_ui_features.cc#L17) |
| `BraveTranslateEnabled` | IOS | [BraveTranslateiOSStudy](https://github.com/brave/brave-variations/blob/main/studies/BraveTranslateiOSStudy.json5): **100%** | [ENABLED](https://github.com/brave/brave-core/blob/v1.93.138/ios/browser/api/translate/features.mm#L10) |
| `PartitionVisitedLinkDatabaseWithSelfLinks` | desktop + android | [PartitionVisitedLinkDatabaseWithSelfLinks](https://github.com/brave/brave-variations/blob/main/studies/PartitionVisitedLinkDatabaseWithSelfLinks.json5): **100%** enabled | Blink [stable except iOS](https://github.com/chromium/chromium/blob/151.0.7922.173/third_party/blink/renderer/platform/runtime_enabled_features.json5#L4567) |
| `BraveShowStrictFingerprintingMode` | desktop + android | [BraveAggressiveModeRetirementExperiment](https://github.com/brave/brave-variations/blob/main/studies/BraveAggressiveModeRetirementExperiment.json5): **100%** disabled | [DISABLED](https://github.com/brave/brave-core/blob/v1.93.138/components/brave_shields/core/common/features.cc#L100) |
| `BraveEnableAutoTranslate` | desktop + android | [BraveAutoTranslateStudy](https://github.com/brave/brave-variations/blob/main/studies/BraveAutoTranslateStudy.json5): **100%** disabled | [DISABLED](https://github.com/brave/brave-core/blob/v1.93.138/components/translate/core/common/brave_translate_features.cc#L20) |
| `BraveNewsFeedUpdate` | desktop RELEASE | [BraveFeedUpdateStudy](https://github.com/brave/brave-variations/blob/main/studies/BraveFeedUpdateStudy.json5): **100%** enabled | [ENABLED on desktop](https://github.com/brave/brave-core/blob/v1.93.138/components/brave_news/common/features.cc#L20) |
| `BraveBlockScreenFingerprinting` | desktop | [BraveScreenFingerprintingBlockerStudy](https://github.com/brave/brave-variations/blob/main/studies/BraveScreenFingerprintingBlockerStudy.json5): **100%** enabled | [ENABLED on desktop](https://github.com/brave/brave-core/blob/v1.93.138/chromium_src/third_party/blink/common/features.cc#L50) |