### PR TITLE
Set max_version for removed studies

### DIFF
--- a/studies/AllowCertainClientHintsStudy.json5
+++ b/studies/AllowCertainClientHintsStudy.json5
@@ -18,6 +18,7 @@
     ],
     filter: {
       min_version: '104.1.44.59',
+      max_version: '151.*',
       channel: [
         'RELEASE',
         'BETA',

--- a/studies/BraveP3AJSONOtherDeprecation.json5
+++ b/studies/BraveP3AJSONOtherDeprecation.json5
@@ -17,6 +17,7 @@
       },
     ],
     filter: {
+      max_version: '151.*',
       channel: [
         'NIGHTLY',
         'BETA',

--- a/studies/BraveP3ATypicalJSONDeprecationEnabled.json5
+++ b/studies/BraveP3ATypicalJSONDeprecationEnabled.json5
@@ -17,6 +17,7 @@
       },
     ],
     filter: {
+      max_version: '151.*',
       channel: [
         'NIGHTLY',
         'BETA',

--- a/studies/BraveRewardsNewRewardsUIStudy.json5
+++ b/studies/BraveRewardsNewRewardsUIStudy.json5
@@ -17,6 +17,7 @@
       },
     ],
     filter: {
+      max_version: '151.*',
       channel: [
         'NIGHTLY',
         'BETA',
@@ -47,6 +48,7 @@
     ],
     filter: {
       min_version: '133.*',
+      max_version: '151.*',
       channel: [
         'RELEASE',
       ],
@@ -75,6 +77,7 @@
       },
     ],
     filter: {
+      max_version: '151.*',
       channel: [
         'NIGHTLY',
         'BETA',
@@ -103,6 +106,7 @@
     ],
     filter: {
       min_version: '135.1.77.95',
+      max_version: '151.*',
       channel: [
         'RELEASE',
       ],

--- a/studies/BraveRewardsWebUiPanelStudy.json5
+++ b/studies/BraveRewardsWebUiPanelStudy.json5
@@ -18,6 +18,7 @@
     ],
     filter: {
       min_version: '103.1.43.9',
+      max_version: '151.*',
       channel: [
         'NIGHTLY',
         'BETA',

--- a/studies/ClampPlatformVersionClientHint.json5
+++ b/studies/ClampPlatformVersionClientHint.json5
@@ -14,6 +14,7 @@
     ],
     filter: {
       min_version: '114.1.52.78',
+      max_version: '151.*',
       channel: [
         'RELEASE',
         'BETA',

--- a/studies/NewiOSMenuUIStudy.json5
+++ b/studies/NewiOSMenuUIStudy.json5
@@ -17,6 +17,7 @@
       },
     ],
     filter: {
+      max_version: '151.*',
       channel: [
         'RELEASE',
         'NIGHTLY',

--- a/studies/NewiOSPlaylistUIStudy.json5
+++ b/studies/NewiOSPlaylistUIStudy.json5
@@ -17,6 +17,7 @@
       },
     ],
     filter: {
+      max_version: '151.*',
       channel: [
         'NIGHTLY',
         'BETA',

--- a/studies/NewiOSTabTrayUIStudy.json5
+++ b/studies/NewiOSTabTrayUIStudy.json5
@@ -17,6 +17,7 @@
       },
     ],
     filter: {
+      max_version: '151.*',
       channel: [
         'BETA',
         'NIGHTLY',
@@ -45,6 +46,7 @@
     ],
     filter: {
       min_version: '141.1.83.118',
+      max_version: '151.*',
       channel: [
         'RELEASE',
       ],

--- a/studies/PartitionedCookies.json5
+++ b/studies/PartitionedCookies.json5
@@ -18,6 +18,7 @@
     ],
     filter: {
       min_version: '122.1.63.0',
+      max_version: '151.*',
       channel: [
         'NIGHTLY',
         'BETA',

--- a/studies/UseFreedesktopSecretKeyProviderKillSwitch.json5
+++ b/studies/UseFreedesktopSecretKeyProviderKillSwitch.json5
@@ -18,6 +18,7 @@
     ],
     filter: {
       min_version: '135.*',
+      max_version: '151.*',
       channel: [
         'NIGHTLY',
         'BETA',

--- a/studies/iOSChromiumWebViewsStudy.json5
+++ b/studies/iOSChromiumWebViewsStudy.json5
@@ -18,6 +18,7 @@
     ],
     filter: {
       min_version: '137.1.80.103',
+      max_version: '151.*',
       channel: [
         'BETA',
         'NIGHTLY',
@@ -46,6 +47,7 @@
     ],
     filter: {
       min_version: '139.1.81.134',
+      max_version: '151.*',
       channel: [
         'RELEASE',
       ],


### PR DESCRIPTION
The PRs sets `max_version: 151.*` for studies that were removed from the code for a while (the most recent feature was removed 20 Mar 2026).
No behaviors changes are expected.

| study name (feature name) | type | the PR it was removed | last state in the code |
|---|---|---|---|
| AllowCertainClientHintsStudy (`AllowCertainClientHints`) | Brave | [brave-core#21822](https://github.com/brave/brave-core/pull/21822/files#diff-2a51b241cb3c5d86f245bd2d0b9901f3eb6fe361a9ce0a6d3182a4e36f7118c4) | ENABLED |
| BraveP3AJSONOtherDeprecation (`BraveP3AOtherJSONDeprecation`) | Brave | [brave-core#29508](https://github.com/brave/brave-core/pull/29508/files#diff-21e83ca61a443e0b7ce8d2f42affeedf2077c6efc721a9ac8aecb3a03b34cc03) | DISABLED |
| BraveP3ATypicalJSONDeprecationEnabled (`BraveP3ATypicalJSONDeprecation`) | Brave | [brave-core#29508](https://github.com/brave/brave-core/pull/29508/files#diff-21e83ca61a443e0b7ce8d2f42affeedf2077c6efc721a9ac8aecb3a03b34cc03) | DISABLED |
| BraveRewardsNewRewardsUIStudy (`BraveRewardsNewRewardsUI`) | Brave | [brave-core#28199](https://github.com/brave/brave-core/pull/28199/files#diff-1bf1478f9bd23f91afa4232808b62863978af800b1c8f8fd8a186482b3ab8b7b) | ENABLED |
| BraveRewardsWebUiPanelStudy (`BraveRewardsWebUIPanel`) | Brave | [brave-core#15342](https://github.com/brave/brave-core/pull/15342/files#diff-6523d69aa2b9e67249a5f71bd635b1effca2a09722972e4fd4fe71fd55c3da48) | DISABLED |
| ~~BuiltInAIAPIsDisabledStudy(`BuiltInAIAPI`)~~ | Chrome | [chromium CL](https://chromium-review.googlesource.com/c/chromium/src/+/7113275) [brave-core PR](https://github.com/brave/brave-core/pull/31337/files#diff-003f29d10c6d185ad89103a1253f05c06bb807a981a679a88dd8c02c079b4c14)| ENABLED in Chromium, DISABLED in Brave |
| ClampPlatformVersionClientHint (`ClampPlatformVersionClientHint`) | Brave | [brave-core#20136](https://github.com/brave/brave-core/pull/20136/files#diff-2a51b241cb3c5d86f245bd2d0b9901f3eb6fe361a9ce0a6d3182a4e36f7118c4) | ENABLED |
| NewiOSMenuUIStudy (`ModernBrowserMenuEnabled`) | Brave | [brave-core#29994](https://github.com/brave/brave-core/pull/29994/files#diff-a4c35b50297ad75bcf51ac1d43451239ef9970743bb234f1a80f65a73adf3f61) | ENABLED |
| NewiOSPlaylistUIStudy (`NewPlaylistUI`) | Brave | [brave-core#29996](https://github.com/brave/brave-core/pull/29996/files#diff-3419754779820da6822eba3bccc563e74c89a0f2c2591222160cccdef63899ae) | ENABLED |
| NewiOSTabTrayUIStudy (`ModernTabTrayEnabled`) | Brave | [brave-core#34840](https://github.com/brave/brave-core/pull/34840/files#diff-4f15371b3a0f1650711fb1e34d7ae0c0bcee853bfa2b690aabf3d0dca5afe7f2) | ENABLED || PartitionedCookies (`PartitionedCookies`) | Chrome | [chromium CL 5301237](https://chromium-review.googlesource.com/c/chromium/src/+/5301237) | ENABLED |
| PartitionedCookies (`PartitionedCookies`) | removed from Chrome | [chromium CL 5301237](https://chromium-review.googlesource.com/c/chromium/src/+/5301237) | ENABLED |
| UseFreedesktopSecretKeyProviderKillSwitch (`UseFreedesktopSecretKeyProvider`) | Chrome | [chromium CL 7027592](https://chromium-review.googlesource.com/c/chromium/src/+/7027592) | ENABLED |
| iOSChromiumWebViewsStudy (`UseChromiumWebViews`) | Brave | [brave-core#34018](https://github.com/brave/brave-core/pull/34018/files#diff-eb55a2882111c372b8c0ce080cfb1cd123f07debf25a89f2e32ecee683dcb2b4) | ENABLED |
