### PR TITLE
Add headers for study files

### DIFF
--- a/src/seed_tools/commands/find_outdated_studies.ts
+++ b/src/seed_tools/commands/find_outdated_studies.ts
@@ -15,7 +15,8 @@ const REPO_BLOB_BASE = 'https://github.com/brave/brave-variations/blob/main/';
 export default function createCommand() {
   return new Command('find_outdated_studies')
     .description(
-      'Find outdated studies: no max_version set and last modified N+ months ago.',
+      'Find outdated studies: no max_version set and last modified N+ months ago. ' +
+        '// !Expire date: <ISO-8601> overrides the last-modified cutoff.',
     )
     .argument(
       '[studies_dir]',
@@ -87,7 +88,7 @@ async function findOutdatedStudies(
   for (const file of files) {
     const filePath = path.join(studiesDir, file);
     const content = await fs.promises.readFile(filePath, 'utf8');
-    const { studies, errors } = parseStudyFile(filePath, content);
+    const { studies, errors, expireDate } = parseStudyFile(filePath, content);
     if (errors.length > 0) {
       console.error(`Error parsing ${filePath}:\n${errors.join('\n')}`);
       process.exit(1);
@@ -98,7 +99,7 @@ async function findOutdatedStudies(
     }
 
     const { commit, date } = getLastCommit(filePath);
-    if (date >= cutoff) {
+    if (isWithinReviewWindow(date, cutoff, expireDate)) {
       continue;
     }
 
@@ -111,6 +112,21 @@ async function findOutdatedStudies(
   }
 
   return outdated;
+}
+
+// Last-modified on/after cutoff means the study is still in the review window.
+// `expireDate` overrides that: the study stays in the window until that
+// timestamp, then is reported regardless of last-modified.
+export function isWithinReviewWindow(
+  lastModified: Date,
+  cutoff: Date,
+  expireDate: Date | undefined,
+  now = new Date(),
+): boolean {
+  if (expireDate !== undefined) {
+    return expireDate >= now;
+  }
+  return lastModified >= cutoff;
 }
 
 function getLastCommit(filePath: string): {

--- a/src/seed_tools/commands/find_outdated_studies.ts
+++ b/src/seed_tools/commands/find_outdated_studies.ts
@@ -16,7 +16,7 @@ export default function createCommand() {
   return new Command('find_outdated_studies')
     .description(
       'Find outdated studies: no max_version set and last modified N+ months ago. ' +
-        '// !Expire date: <ISO-8601> overrides the last-modified cutoff.',
+        '// !Expiry Date: <ISO-8601> overrides the last-modified cutoff.',
     )
     .argument(
       '[studies_dir]',
@@ -88,7 +88,7 @@ async function findOutdatedStudies(
   for (const file of files) {
     const filePath = path.join(studiesDir, file);
     const content = await fs.promises.readFile(filePath, 'utf8');
-    const { studies, errors, expireDate } = parseStudyFile(filePath, content);
+    const { studies, errors, expiryDate } = parseStudyFile(filePath, content);
     if (errors.length > 0) {
       console.error(`Error parsing ${filePath}:\n${errors.join('\n')}`);
       process.exit(1);
@@ -99,7 +99,7 @@ async function findOutdatedStudies(
     }
 
     const { commit, date } = getLastCommit(filePath);
-    if (isWithinReviewWindow(date, cutoff, expireDate)) {
+    if (isWithinReviewWindow(date, cutoff, expiryDate)) {
       continue;
     }
 
@@ -115,16 +115,16 @@ async function findOutdatedStudies(
 }
 
 // Last-modified on/after cutoff means the study is still in the review window.
-// `expireDate` overrides that: the study stays in the window until that
+// `expiryDate` overrides that: the study stays in the window until that
 // timestamp, then is reported regardless of last-modified.
 export function isWithinReviewWindow(
   lastModified: Date,
   cutoff: Date,
-  expireDate: Date | undefined,
+  expiryDate: Date | undefined,
   now = new Date(),
 ): boolean {
-  if (expireDate !== undefined) {
-    return expireDate >= now;
+  if (expiryDate !== undefined) {
+    return expiryDate >= now;
   }
   return lastModified >= cutoff;
 }

--- a/src/seed_tools/utils/studies_to_seed.ts
+++ b/src/seed_tools/utils/studies_to_seed.ts
@@ -167,7 +167,10 @@ async function checkAndOptionallyFixFormat(
   fix: boolean,
 ): Promise<string[]> {
   const errors: string[] = [];
-  const stringifiedStudies = study_json_utils.stringifyStudies(studies);
+  const stringifiedStudies = study_json_utils.stringifyStudyFile(
+    studies,
+    studyArrayString,
+  );
   if (stringifiedStudies !== studyArrayString) {
     if (fix) {
       await fs.writeFile(studyFilePath, stringifiedStudies);

--- a/src/seed_tools/utils/study_json_utils.test.ts
+++ b/src/seed_tools/utils/study_json_utils.test.ts
@@ -11,7 +11,12 @@ import {
   Study_Channel,
   Study_Platform,
 } from '../../proto/generated/study';
-import { parseStudies, stringifyStudies } from './study_json_utils';
+import {
+  extractStudyFileHeader,
+  parseStudies,
+  stringifyStudies,
+  stringifyStudyFile,
+} from './study_json_utils';
 
 describe('stringifyStudies', () => {
   it('should convert start_date and end_date to ISO string', () => {
@@ -299,5 +304,34 @@ describe('parseStudies', () => {
       Study_Channel.BETA,
       Study_Channel.STABLE,
     ]);
+  });
+});
+
+describe('study file header', () => {
+  const study = Study.fromJson(
+    { name: 'study' },
+    { ignoreUnknownFields: false },
+  );
+  const formattedBody = stringifyStudies([study]);
+
+  it('extracts leading // ! comments', () => {
+    assert.strictEqual(
+      extractStudyFileHeader(`// ! Deprecated\n${formattedBody}`),
+      '// ! Deprecated\n',
+    );
+    assert.strictEqual(
+      extractStudyFileHeader(
+        `// ! Deprecated\n// ! See issue 1\n${formattedBody}`,
+      ),
+      '// ! Deprecated\n// ! See issue 1\n',
+    );
+  });
+
+  it('stringifyStudyFile preserves the header', () => {
+    const original = `// !Expire date: 2026-01-01\n// !Some\n[{name:'study'}]\n`;
+    assert.strictEqual(
+      stringifyStudyFile(parseStudies(original), original),
+      `// !Expire date: 2026-01-01\n// !Some\n${formattedBody}`,
+    );
   });
 });

--- a/src/seed_tools/utils/study_json_utils.test.ts
+++ b/src/seed_tools/utils/study_json_utils.test.ts
@@ -14,6 +14,7 @@ import {
 import {
   extractStudyFileHeader,
   parseStudies,
+  parseStudyFileHeader,
   stringifyStudies,
   stringifyStudyFile,
 } from './study_json_utils';
@@ -327,11 +328,23 @@ describe('study file header', () => {
     );
   });
 
-  it('stringifyStudyFile preserves the header', () => {
+  it('Header with Expire date', () => {
     const original = `// !Expire date: 2026-01-01\n// !Some\n[{name:'study'}]\n`;
+    assert.deepStrictEqual(
+      parseStudyFileHeader(`// !Expire date: 2026-01-01\n${formattedBody}`),
+      { expireDate: new Date('2026-01-01') },
+    );
     assert.strictEqual(
       stringifyStudyFile(parseStudies(original), original),
       `// !Expire date: 2026-01-01\n// !Some\n${formattedBody}`,
+    );
+  });
+
+  it('rejects an invalid Expire date', () => {
+    assert.throws(
+      () =>
+        parseStudyFileHeader(`// !Expire date: 20-031-01\n${formattedBody}`),
+      /Invalid Expire date value "20-031-01"/,
     );
   });
 });

--- a/src/seed_tools/utils/study_json_utils.test.ts
+++ b/src/seed_tools/utils/study_json_utils.test.ts
@@ -328,23 +328,23 @@ describe('study file header', () => {
     );
   });
 
-  it('Header with Expire date', () => {
-    const original = `// !Expire date: 2026-01-01\n// !Some\n[{name:'study'}]\n`;
+  it('Header with Expiry Date', () => {
+    const original = `// !Expiry Date: 2026-01-01\n// !Some\n[{name:'study'}]\n`;
     assert.deepStrictEqual(
-      parseStudyFileHeader(`// !Expire date: 2026-01-01\n${formattedBody}`),
-      { expireDate: new Date('2026-01-01') },
+      parseStudyFileHeader(`// !Expiry Date: 2026-01-01\n${formattedBody}`),
+      { expiryDate: new Date('2026-01-01') },
     );
     assert.strictEqual(
       stringifyStudyFile(parseStudies(original), original),
-      `// !Expire date: 2026-01-01\n// !Some\n${formattedBody}`,
+      `// !Expiry Date: 2026-01-01\n// !Some\n${formattedBody}`,
     );
   });
 
-  it('rejects an invalid Expire date', () => {
+  it('rejects an invalid Expiry Date', () => {
     assert.throws(
       () =>
-        parseStudyFileHeader(`// !Expire date: 20-031-01\n${formattedBody}`),
-      /Invalid Expire date value "20-031-01"/,
+        parseStudyFileHeader(`// !Expiry Date: 20-031-01\n${formattedBody}`),
+      /Invalid Expiry Date value "20-031-01"/,
     );
   });
 });

--- a/src/seed_tools/utils/study_json_utils.ts
+++ b/src/seed_tools/utils/study_json_utils.ts
@@ -18,6 +18,24 @@ export function extractStudyFileHeader(content: string): string {
   return STUDY_FILE_HEADER_PATTERN.exec(content)?.[0] ?? '';
 }
 
+export function parseStudyFileHeader(content: string): {
+  expireDate?: Date;
+} {
+  const header = extractStudyFileHeader(content);
+  let expireDate: Date | undefined = undefined;
+  for (const line of header.split('\n')) {
+    const EXPIRE_DATE_PREFIX = '// !Expire date:';
+    if (line.startsWith(EXPIRE_DATE_PREFIX)) {
+      const value = line.slice(EXPIRE_DATE_PREFIX.length).trim();
+      expireDate = new Date(value);
+      if (Number.isNaN(expireDate.getTime())) {
+        throw new Error(`Invalid Expire date value "${value}"`);
+      }
+    }
+  }
+  return { expireDate };
+}
+
 export function parseStudyFile(
   studyFilePath: string,
   studyFileContent: string,
@@ -25,11 +43,13 @@ export function parseStudyFile(
 ): {
   studies: Study[];
   errors: string[];
+  expireDate?: Date;
 } {
   let studies: Study[] = [];
   try {
+    const { expireDate } = parseStudyFileHeader(studyFileContent);
     studies = parseStudies(studyFileContent, options);
-    return { studies, errors: [] };
+    return { studies, errors: [], expireDate };
   } catch (e) {
     if (e instanceof Error) {
       e.message += ` (${studyFilePath})`;

--- a/src/seed_tools/utils/study_json_utils.ts
+++ b/src/seed_tools/utils/study_json_utils.ts
@@ -12,6 +12,12 @@ export interface Options {
   isChromium?: boolean;
 }
 
+// Extracts the leading `// ! ...` comments from the study file content.
+export function extractStudyFileHeader(content: string): string {
+  const STUDY_FILE_HEADER_PATTERN = /^(?:\/\/ !.*\n)+/;
+  return STUDY_FILE_HEADER_PATTERN.exec(content)?.[0] ?? '';
+}
+
 export function parseStudyFile(
   studyFilePath: string,
   studyFileContent: string,
@@ -84,6 +90,16 @@ export function stringifyStudies(studies: Study[], options?: Options): string {
   return (
     JSON5.stringify(jsonStudies, jsonStudyReplacer.bind(null, options), 2) +
     '\n'
+  );
+}
+
+export function stringifyStudyFile(
+  studies: Study[],
+  originalContent: string,
+  options?: Options,
+): string {
+  return (
+    extractStudyFileHeader(originalContent) + stringifyStudies(studies, options)
   );
 }
 

--- a/src/seed_tools/utils/study_json_utils.ts
+++ b/src/seed_tools/utils/study_json_utils.ts
@@ -19,21 +19,21 @@ export function extractStudyFileHeader(content: string): string {
 }
 
 export function parseStudyFileHeader(content: string): {
-  expireDate?: Date;
+  expiryDate?: Date;
 } {
   const header = extractStudyFileHeader(content);
-  let expireDate: Date | undefined = undefined;
+  let expiryDate: Date | undefined = undefined;
   for (const line of header.split('\n')) {
-    const EXPIRE_DATE_PREFIX = '// !Expire date:';
-    if (line.startsWith(EXPIRE_DATE_PREFIX)) {
-      const value = line.slice(EXPIRE_DATE_PREFIX.length).trim();
-      expireDate = new Date(value);
-      if (Number.isNaN(expireDate.getTime())) {
-        throw new Error(`Invalid Expire date value "${value}"`);
+    const EXPIRY_DATE_PREFIX = '// !Expiry Date:';
+    if (line.startsWith(EXPIRY_DATE_PREFIX)) {
+      const value = line.slice(EXPIRY_DATE_PREFIX.length).trim();
+      expiryDate = new Date(value);
+      if (Number.isNaN(expiryDate.getTime())) {
+        throw new Error(`Invalid Expiry Date value "${value}"`);
       }
     }
   }
-  return { expireDate };
+  return { expiryDate };
 }
 
 export function parseStudyFile(
@@ -43,13 +43,13 @@ export function parseStudyFile(
 ): {
   studies: Study[];
   errors: string[];
-  expireDate?: Date;
+  expiryDate?: Date;
 } {
   let studies: Study[] = [];
   try {
-    const { expireDate } = parseStudyFileHeader(studyFileContent);
+    const { expiryDate } = parseStudyFileHeader(studyFileContent);
     studies = parseStudies(studyFileContent, options);
-    return { studies, errors: [], expireDate };
+    return { studies, errors: [], expiryDate };
   } catch (e) {
     if (e instanceof Error) {
       e.message += ` (${studyFilePath})`;

--- a/src/test/data/unformatted_studies/test1/expected_output.txt
+++ b/src/test/data/unformatted_studies/test1/expected_output.txt
@@ -1,4 +1,4 @@
-@@ -7,7 +7,7 @@
+@@ -8,7 +8,7 @@
          probability_weight: 100,
          feature_association: {
            enable_feature: [
@@ -7,7 +7,7 @@
            ],
          },
        },
-@@ -21,17 +21,17 @@
+@@ -22,17 +22,17 @@
          },
        },
        {

--- a/src/test/data/unformatted_studies/test1/studies/TestStudy.json5
+++ b/src/test/data/unformatted_studies/test1/studies/TestStudy.json5
@@ -1,3 +1,4 @@
+// ! Test header
 [
   {
     name: 'TestStudy',

--- a/src/test/data/valid_seeds/test1/studies/TestStudy.json5
+++ b/src/test/data/valid_seeds/test1/studies/TestStudy.json5
@@ -1,3 +1,4 @@
+// ! Test header
 [
   {
     name: 'TestStudy',


### PR DESCRIPTION
The PR adds header support to study files.
Currently, only one header `// !Expired date: ..` is supported.
It's used to make an exception from find_outdated_study script.