### PR TITLE
Set max_version for studies (part 5)

### DIFF
--- a/studies/AdaptiveButtonInTopToolbarCustomizationV2.json5
+++ b/studies/AdaptiveButtonInTopToolbarCustomizationV2.json5
@@ -13,6 +13,7 @@
       },
     ],
     filter: {
+      max_version: '152.*',
       channel: [
         'NIGHTLY',
       ],
@@ -36,6 +37,7 @@
     ],
     filter: {
       min_version: '142.1.85.87',
+      max_version: '152.*',
       channel: [
         'BETA',
       ],
@@ -59,6 +61,7 @@
     ],
     filter: {
       min_version: '143.1.85.111',
+      max_version: '152.*',
       channel: [
         'RELEASE',
       ],

--- a/studies/BraveAdsNewTabPageAdsStudy.json5
+++ b/studies/BraveAdsNewTabPageAdsStudy.json5
@@ -67,6 +67,7 @@
     ],
     filter: {
       min_version: '137.1.80.31',
+      max_version: '152.*',
       channel: [
         'NIGHTLY',
         'BETA',
@@ -105,6 +106,7 @@
     ],
     filter: {
       min_version: '138.1.80.122',
+      max_version: '152.*',
       channel: [
         'RELEASE',
       ],
@@ -141,6 +143,7 @@
     ],
     filter: {
       min_version: '138.1.80.121',
+      max_version: '152.*',
       channel: [
         'RELEASE',
       ],

--- a/studies/CrossPlatformVPNStudy.json5
+++ b/studies/CrossPlatformVPNStudy.json5
@@ -19,6 +19,7 @@
     ],
     filter: {
       min_version: '110.1.49.120',
+      max_version: '152.*',
       channel: [
         'NIGHTLY',
         'BETA',

--- a/studies/HistoryEmbeddingsParamsStudy.json5
+++ b/studies/HistoryEmbeddingsParamsStudy.json5
@@ -26,6 +26,7 @@
     ],
     filter: {
       min_version: '147.1.91.110',
+      max_version: '152.*',
       channel: [
         'NIGHTLY',
         'BETA',

--- a/studies/MetricsAndCrashSampling.json5
+++ b/studies/MetricsAndCrashSampling.json5
@@ -17,6 +17,7 @@
       },
     ],
     filter: {
+      max_version: '152.*',
       channel: [
         'NIGHTLY',
         'BETA',

--- a/studies/PostFREFixMetricsAndCrashSampling.json5
+++ b/studies/PostFREFixMetricsAndCrashSampling.json5
@@ -17,6 +17,7 @@
       },
     ],
     filter: {
+      max_version: '152.*',
       channel: [
         'NIGHTLY',
         'BETA',

--- a/studies/ZCashStudy.json5
+++ b/studies/ZCashStudy.json5
@@ -24,6 +24,7 @@
     ],
     filter: {
       min_version: '139.1.81.129',
+      max_version: '152.*',
       channel: [
         'RELEASE',
         'NIGHTLY',

--- a/studies/iOSWalletWebUIStudy.json5
+++ b/studies/iOSWalletWebUIStudy.json5
@@ -15,6 +15,7 @@
     ],
     filter: {
       min_version: '146.1.89.116',
+      max_version: '152.*',
       channel: [
         'NIGHTLY',
         'BETA',
@@ -49,6 +50,7 @@
     ],
     filter: {
       min_version: '146.1.89.116',
+      max_version: '152.*',
       channel: [
         'NIGHTLY',
         'BETA',
@@ -78,6 +80,7 @@
     ],
     filter: {
       min_version: '147.1.89.144',
+      max_version: '152.*',
       channel: [
         'RELEASE',
       ],
@@ -111,6 +114,7 @@
     ],
     filter: {
       min_version: '147.1.89.144',
+      max_version: '152.*',
       channel: [
         'RELEASE',
       ],


### PR DESCRIPTION
| study name (feature name) | type | platforms | proof (v1.94.117/cr152) |
|---|---|---|---|
| [AdaptiveButtonInTopToolbarCustomizationV2](https://github.com/brave/brave-variations/blob/main/studies/AdaptiveButtonInTopToolbarCustomizationV2.json5) (`AdaptiveButtonInTopToolbarCustomizationV2`) | chrome | android | [ENABLED](https://github.com/chromium/chromium/blob/152.0.7977.64/chrome/browser/flags/android/chrome_feature_list.cc#L600) |
| [BraveAdsNewTabPageAdsStudy](https://github.com/brave/brave-variations/blob/main/studies/BraveAdsNewTabPageAdsStudy.json5) (`NewTabPageAds`) has `should_support_confirmations_for_non_rewards` removed from the code| brave | desktop + android + ios | [ENABLED](https://github.com/brave/brave-core/blob/v1.94.117/components/brave_ads/core/internal/ad_units/new_tab_page_ad/new_tab_page_ad_feature.cc#L10) |
| [CrossPlatformVPNStudy](https://github.com/brave/brave-variations/blob/main/studies/CrossPlatformVPNStudy.json5) (`BraveVPN`, `BraveVPNLinkSubscriptionAndroidUI`) | brave | desktop + android | [VPN ENABLED except Linux](https://github.com/brave/brave-core/blob/v1.94.117/components/brave_vpn/common/features.cc#L15), [LinkSubscription ENABLED](https://github.com/brave/brave-core/blob/v1.94.117/components/brave_vpn/common/features.cc#L25) |
| [HistoryEmbeddingsParamsStudy](https://github.com/brave/brave-variations/blob/main/studies/HistoryEmbeddingsParamsStudy.json5) (`HistoryEmbeddings`) | chrome | desktop | [DISABLED](https://github.com/brave/brave-core/blob/v1.94.117/chromium_src/components/history_embeddings/core/history_embeddings_features.cc#L16) |
| [MetricsAndCrashSampling](https://github.com/brave/brave-variations/blob/main/studies/MetricsAndCrashSampling.json5) (`MetricsReporting`) | chrome | android | [ENABLED](https://github.com/chromium/chromium/blob/152.0.7977.64/chrome/browser/metrics/chrome_metrics_services_manager_client.cc#L71) |
| [PostFREFixMetricsAndCrashSampling](https://github.com/brave/brave-variations/blob/main/studies/PostFREFixMetricsAndCrashSampling.json5) (`PostFREFixMetricsReporting`) | chrome | android | [ENABLED](https://github.com/chromium/chromium/blob/152.0.7977.64/chrome/browser/metrics/chrome_metrics_services_manager_client.cc#L81) |
| [ZCashStudy](https://github.com/brave/brave-variations/blob/main/studies/ZCashStudy.json5) (`BraveWalletZCash`) | brave | desktop + android | [ENABLED](https://github.com/brave/brave-core/blob/v1.94.117/components/brave_wallet/common/features.cc#L29) [zcash_shielded_transactions_enabled](https://github.com/brave/brave-core/blob/v1.94.117/components/brave_wallet/common/features.cc#L58) |
| [iOSWalletWebUIStudy](https://github.com/brave/brave-variations/blob/main/studies/iOSWalletWebUIStudy.json5) (`BraveWalletWebUIFeature`, `BraveWalletCardano`, `BraveWalletZCash`) | brave | ios | [WebUI ENABLED](https://github.com/brave/brave-core/blob/v1.94.117/components/brave_wallet/common/features.cc#L81), [Cardano ENABLED](https://github.com/brave/brave-core/blob/v1.94.117/components/brave_wallet/common/features.cc#L43), [ZCash ENABLED](https://github.com/brave/brave-core/blob/v1.94.117/components/brave_wallet/common/features.cc#L29) |