### PR TITLE
A better logic to identify chromium major for griffin.brave.com

### DIFF
--- a/src/core/url_utils.ts
+++ b/src/core/url_utils.ts
@@ -9,11 +9,6 @@ export const variationsMainUrl = 'https://variations.brave.com/seed';
 export const variationsUpstreamUrl =
   'https://griffin.brave.com/finch-data-private/seed.bin';
 
-// The API is used to detect the current Chromium major version (i.e. cr117).
-// windows-x64 is used just because it's the lagest desktop.
-export const getUsedChromiumVersionUrl =
-  'https://versions.brave.com/latest/release-windows-x64-chromium.version';
-
 function makeSourceGraphUrl(query: string, repo: string, file: string) {
   return (
     `https://sourcegraph.com/search?q=context:global` +
@@ -61,4 +56,27 @@ export function getStudyRawConfigUrl(
 // Returns a link to see the study config at griffin.brave.com.
 export function getGriffinUiUrl(study: string): string {
   return `https://griffin.brave.com/?seed=UPSTREAM&search=${study}`;
+}
+
+let chromiumVersionForBraveStablePromise: Promise<number> | undefined;
+
+// The API is used to detect the current Chromium major version (i.e. cr117).
+export async function GetChromiumVersionForBraveStable(): Promise<number> {
+  return (chromiumVersionForBraveStablePromise ??= (async () => {
+    const getVersion = async (url: string) => {
+      const response = await fetch(url, { cache: 'no-store' });
+      const text = await response.text();
+      return parseInt(text.split('.')[0]);
+    };
+
+    const [windows_version, android_version] = await Promise.all([
+      getVersion(
+        'https://versions.brave.com/latest/release-windows-x64-chromium.version',
+      ),
+      getVersion(
+        'https://versions.brave.com/latest/release-android-chromium.version',
+      ),
+    ]);
+    return Math.min(windows_version, android_version);
+  })());
 }

--- a/src/finch_tracker/main.ts
+++ b/src/finch_tracker/main.ts
@@ -9,7 +9,7 @@ import { StudyPriority } from '../core/study_processor';
 import { makeSummary, summaryToJson } from '../core/summary';
 import * as url_utils from '../core/url_utils';
 import { VariationsSeed } from '../proto/generated/variations_seed';
-import { downloadUrl, getSeedPath } from './node_utils';
+import { getSeedPath } from './node_utils';
 import {
   commitAllChanges,
   fetchChromeSeedData,
@@ -35,7 +35,7 @@ async function main(): Promise<void> {
       '-m, --chrome-major <number>',
       'Override the current stable major chrome version.' +
         'By default the version is taken from the backend' +
-        '(see getUsedChromiumVersionUrl)',
+        '(see url_utils.GetChromiumVersionForBraveStable)',
       parseInt,
     )
     .option('--no-update', "Don't make any disk changes")
@@ -51,21 +51,7 @@ async function main(): Promise<void> {
   const previousSeedFile = program.args[2];
   let minMajorVersion = program.opts().chromeMajor;
 
-  if (minMajorVersion === undefined) {
-    const chromiumVersionData = await downloadUrl(
-      url_utils.getUsedChromiumVersionUrl,
-    );
-    const chromiumVersionString = chromiumVersionData?.toString().split('.')[0];
-    if (chromiumVersionString === undefined) {
-      program.error(
-        'Failed to get the Chromium version from ' +
-          url_utils.getUsedChromiumVersionUrl,
-      );
-      return;
-    }
-    console.log('Got Chromium version', chromiumVersionString);
-    minMajorVersion = parseInt(chromiumVersionString);
-  }
+  minMajorVersion ??= await url_utils.GetChromiumVersionForBraveStable();
 
   const options: ProcessingOptions = {
     minMajorVersion,
@@ -82,10 +68,11 @@ async function main(): Promise<void> {
     return;
   }
 
-  const seedData =
+  const seedData = new Uint8Array(
     seedFile !== undefined
       ? fs.readFileSync(seedFile)
-      : await fetchChromeSeedData();
+      : await fetchChromeSeedData(),
+  );
   const seed = VariationsSeed.fromBinary(seedData);
   let previousSeedData: Buffer | undefined;
   let newGitSha1: string | undefined;

--- a/src/finch_tracker/tracker_lib.ts
+++ b/src/finch_tracker/tracker_lib.ts
@@ -16,17 +16,17 @@ import {
 import { Study } from '../proto/generated/study';
 import { VariationsSeed } from '../proto/generated/variations_seed';
 import { writeStudyFile } from '../seed_tools/utils/study_json_utils';
-import { downloadUrl, getSeedPath, getStudyPath } from './node_utils';
+import { getSeedPath, getStudyPath } from './node_utils';
 
-export async function fetchChromeSeedData(): Promise<Buffer> {
+export async function fetchChromeSeedData(): Promise<ArrayBuffer> {
   const kChromeSeedUrl =
     'https://clientservices.googleapis.com/chrome-variations/seed';
-  return await downloadUrl(kChromeSeedUrl);
+  return await (await fetch(kChromeSeedUrl)).arrayBuffer();
 }
 
 // Groups studies by name and priority.
 export function groupStudies(
-  seedData: Buffer,
+  seedData: Uint8Array,
   options: ProcessingOptions,
 ): Record<string, Study[]> {
   const map: Record<string, Study[]> = {};
@@ -77,7 +77,7 @@ export function commitAllChanges(directory: string): string | undefined {
 // Processes and serializes a given seed to disk (including grouping to
 // subdirectories/files).
 export async function storeDataToDirectory(
-  seedData: Buffer,
+  seedData: Uint8Array,
   directory: string,
   options: ProcessingOptions,
 ): Promise<void> {

--- a/src/web/app/seed_loader.ts
+++ b/src/web/app/seed_loader.ts
@@ -10,51 +10,13 @@ import { StudyListModel, StudyModel } from './study_model';
 
 import * as url_utils from '../../core/url_utils';
 
-const getCurrentMajorVersion = new Promise<number>((resolve) => {
-  loadFile(url_utils.getUsedChromiumVersionUrl, 'text')
-    .then((chromeVersionData) => {
-      if (chromeVersionData !== undefined)
-        resolve(chromeVersionData.split('.')[0] ?? 0);
-      resolve(0);
-    })
-    .catch(() => {
-      resolve(0);
-    });
-});
-
-async function loadFile(
-  url: string,
-  responseType: 'arraybuffer' | 'text',
-): Promise<any> {
-  return await new Promise<any>((resolve, reject) => {
-    const xhr = new XMLHttpRequest();
-    xhr.open('GET', url, true /* async */);
-    xhr.responseType = responseType;
-    xhr.onload = () => {
-      if (xhr.status === 200) {
-        resolve(xhr.response);
-      } else {
-        reject(new Error('HTTP status:' + xhr.status));
-      }
-    };
-    xhr.onerror = () => {
-      reject(new Error('XHR error'));
-    };
-    xhr.send(null);
-  });
-}
-
 async function loadSeedFromUrl(url: string, type: SeedType) {
-  const data = await loadFile(url, 'arraybuffer');
+  const data = await (await fetch(url)).arrayBuffer();
   const seedBytes = new Uint8Array(data);
   const seed = VariationsSeed.fromBinary(seedBytes);
   const isBraveSeed = type !== SeedType.UPSTREAM;
 
-  // Desktop/Android could use a different major chrome version.
-  // Use -1 version for Brave studies to make sure that we don't cut
-  // anything important.
-  const minMajorVersion =
-    (await getCurrentMajorVersion) - (isBraveSeed ? 1 : 0);
+  const minMajorVersion = await url_utils.GetChromiumVersionForBraveStable();
   const options: ProcessingOptions = { minMajorVersion, isBraveSeed };
   const studies: StudyModel[] = [];
   seed.study.forEach((study, index) => {


### PR DESCRIPTION
The PRs removes -1 adjustment to chromium major version we use griffin.brave.com.
Instead it makes 2 requests (windows + android) and take the minimum.
It also unifies download API in favor of cross-engine `fetch()`.

Only griffin.brave.com and finch tracker are affected.