### PR TITLE
Set max_version for AdblockOnlyModeStudy

### DIFF
--- a/studies/AdblockOnlyModeStudy.json5
+++ b/studies/AdblockOnlyModeStudy.json5
@@ -24,6 +24,7 @@
     ],
     filter: {
       min_version: '143.1.86.96',
+      max_version: '154.1.96.26',
       channel: [
         'BETA',
         'NIGHTLY',
@@ -60,6 +61,7 @@
     ],
     filter: {
       min_version: '145.1.88.96',
+      max_version: '154.1.96.26',
       channel: [
         'RELEASE',
       ],

--- a/studies/AdblockOnlyModeStudy.json5
+++ b/studies/AdblockOnlyModeStudy.json5
@@ -24,7 +24,7 @@
     ],
     filter: {
       min_version: '143.1.86.96',
-      max_version: '154.1.96.26',
+      max_version: '154.1.96.25',
       channel: [
         'BETA',
         'NIGHTLY',


### PR DESCRIPTION
For https://github.com/brave/brave-browser/issues/58088
Enabled by default here: https://github.com/brave/brave-core/pull/39428