### PR TITLE
Set max_version for WebDiscoveryNativeStudy

### DIFF
--- a/studies/WebDiscoveryNativeStudy.json5
+++ b/studies/WebDiscoveryNativeStudy.json5
@@ -24,6 +24,7 @@
     ],
     filter: {
       min_version: '134.1.78.42',
+      max_version: '153.1.96.43',
       channel: [
         'NIGHTLY',
       ],
@@ -57,6 +58,7 @@
     ],
     filter: {
       min_version: '134.1.77.82',
+      max_version: '154.1.96.43',
       channel: [
         'BETA',
       ],
@@ -90,6 +92,7 @@
     ],
     filter: {
       min_version: '134.1.76.78',
+      max_version: '154.1.96.43',
       channel: [
         'RELEASE',
       ],


### PR DESCRIPTION
For https://github.com/brave/brave-browser/issues/58662
Enabled by default here: https://github.com/brave/brave-core/pull/39592