### PR TITLE
Follow upstream and BlockListByModel value for DefaultPassthroughCommandDecoderStudy for 30% of users on RELEASE and set it to 100% for NIGHTLY and BETA

### DIFF
--- a/studies/DefaultPassthroughCommandDecoderStudy.json5
+++ b/studies/DefaultPassthroughCommandDecoderStudy.json5
@@ -14,7 +14,7 @@
         param: [
           {
             name: 'BlockListByModel',
-            value: 'SM-I610|SM-I610H|Robin XR|Android XR Puck|Aura',
+            value: '',
           },
         ],
       },
@@ -28,6 +28,55 @@
       channel: [
         'NIGHTLY',
         'BETA',
+      ],
+      platform: [
+        'ANDROID',
+      ],
+    },
+  },
+  {
+    name: 'DefaultPassthroughCommandDecoderStudy',
+    experiment: [
+      {
+        name: 'Enabled',
+        probability_weight: 70,
+        feature_association: {
+          enable_feature: [
+            'DefaultPassthroughCommandDecoder',
+            'GpuPersistentCache',
+          ],
+        },
+        param: [
+          {
+            name: 'BlockListByModel',
+            value: 'SM-I610|SM-I610H|Robin XR|Android XR Puck|Aura',
+          },
+        ],
+      },
+      {
+        name: 'EnabledWithoutBlockList',
+        probability_weight: 30,
+        feature_association: {
+          enable_feature: [
+            'DefaultPassthroughCommandDecoder',
+            'GpuPersistentCache',
+          ],
+        },
+        param: [
+          {
+            name: 'BlockListByModel',
+            value: '',
+          },
+        ],
+      },
+      {
+        name: 'Default',
+        probability_weight: 0,
+      },
+    ],
+    filter: {
+      min_version: '148.*',
+      channel: [
         'RELEASE',
       ],
       platform: [


### PR DESCRIPTION
Resolves: https://github.com/brave/brave-variations/issues/1875