### PR TITLE
Sets max_version for BraveFreshNtpAfterIdleExperiment feature as we enabled it by default

### DIFF
--- a/studies/BraveDayZeroStudyAndroid.json5
+++ b/studies/BraveDayZeroStudyAndroid.json5
@@ -41,6 +41,7 @@
     ],
     filter: {
       min_version: '146.*',
+      max_version: '153.*',
       channel: [
         'RELEASE',
       ],


### PR DESCRIPTION
The feature was enabled by default in code here https://github.com/brave/brave-core/pull/39010
Resolves: http://github.com/brave/brave-variations/issues/1874